### PR TITLE
Improved Error Handling

### DIFF
--- a/pkg/service/server_test.go
+++ b/pkg/service/server_test.go
@@ -14,6 +14,54 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+func Test_FailureHandler(t *testing.T) {
+	t.Log("Test_FailureHandler: should handle failures")
+	var (
+		sqsStubber = &stubSQS{}
+	)
+
+	asgStubber := &stubAutoscaling{
+		lifecycleHooks: []*autoscaling.LifecycleHook{
+			{
+				AutoScalingGroupName: aws.String("my-asg"),
+				HeartbeatTimeout:     aws.Int64(60),
+			},
+		},
+	}
+
+	auth := Authenticator{
+		ScalingGroupClient: asgStubber,
+		SQSClient:          sqsStubber,
+		KubernetesClient:   fake.NewSimpleClientset(),
+	}
+	ctx := ManagerContext{
+		KubectlLocalPath:       stubKubectlPathSuccess,
+		QueueName:              "my-queue",
+		Region:                 "us-west-2",
+		DrainTimeoutSeconds:    1,
+		PollingIntervalSeconds: 1,
+	}
+
+	fakeMessage := &sqs.Message{
+		// invalid instance id
+		Body:          aws.String(`{"LifecycleHookName":"my-hook","AccountId":"12345689012","RequestId":"63f5b5c2-58b3-0574-b7d5-b3162d0268f0","LifecycleTransition":"autoscaling:EC2_INSTANCE_TERMINATING","AutoScalingGroupName":"my-asg","Service":"AWS Auto Scaling","Time":"2019-09-27T02:39:14.183Z","EC2InstanceId":"","LifecycleActionToken":"cc34960c-1e41-4703-a665-bdb3e5b81ad3"}`),
+		ReceiptHandle: aws.String("MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+Cw="),
+	}
+
+	mgr := New(auth, ctx)
+	mgr.newWorker(fakeMessage)
+
+	expectedFailedEvents := 1
+	if mgr.failedEvents != expectedFailedEvents {
+		t.Fatalf("expected failed events: %v, got: %v", expectedFailedEvents, mgr.failedEvents)
+	}
+
+	expectedDeleteMessageEvents := 1
+	if sqsStubber.timesCalledDeleteMessage != expectedDeleteMessageEvents {
+		t.Fatalf("expected deleted events: %v, got: %v", expectedDeleteMessageEvents, sqsStubber.timesCalledDeleteMessage)
+	}
+}
+
 func Test_Process(t *testing.T) {
 	t.Log("Test_Process: should process events")
 	asgStubber := &stubAutoscaling{}
@@ -135,10 +183,6 @@ func Test_HandleEvent(t *testing.T) {
 	if event.drainCompleted != true {
 		t.Fatal("handleEvent: expected drainCompleted to be true, got: false")
 	}
-
-	if asgStubber.timesCalledCompleteLifecycleAction != 1 {
-		t.Fatalf("handleEvent: expected timesCalledCompleteLifecycleAction to be 1, got: %v", asgStubber.timesCalledCompleteLifecycleAction)
-	}
 }
 
 func Test_HandleEventWithDeregister(t *testing.T) {
@@ -224,14 +268,6 @@ func Test_HandleEventWithDeregister(t *testing.T) {
 
 	if event.deregisterCompleted != true {
 		t.Fatal("handleEvent: expected deregisterCompleted to be true, got: false")
-	}
-
-	if event.eventCompleted != true {
-		t.Fatal("handleEvent: expected eventCompleted to be true, got: false")
-	}
-
-	if asgStubber.timesCalledCompleteLifecycleAction != 1 {
-		t.Fatalf("handleEvent: expected timesCalledCompleteLifecycleAction to be 1, got: %v", asgStubber.timesCalledCompleteLifecycleAction)
 	}
 }
 

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -27,6 +27,7 @@ type Manager struct {
 	workQueue       []*LifecycleEvent
 	workQueueSync   *sync.Mutex
 	completedEvents int
+	rejectedEvents  int
 	failedEvents    int
 }
 

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"reflect"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
@@ -25,40 +24,20 @@ type Manager struct {
 	eventStream     chan *sqs.Message
 	authenticator   Authenticator
 	context         ManagerContext
-	queue           []LifecycleEvent
-	queueSync       *sync.Mutex
+	workQueue       []*LifecycleEvent
+	workQueueSync   *sync.Mutex
 	completedEvents int
+	failedEvents    int
 }
 
 func New(auth Authenticator, ctx ManagerContext) *Manager {
 	return &Manager{
 		eventStream:   make(chan *sqs.Message, 0),
-		queue:         make([]LifecycleEvent, 0),
-		queueSync:     &sync.Mutex{},
+		workQueue:     make([]*LifecycleEvent, 0),
+		workQueueSync: &sync.Mutex{},
 		authenticator: auth,
 		context:       ctx,
 	}
-}
-
-func (mgr *Manager) AddEvent(event LifecycleEvent) {
-	mgr.queueSync.Lock()
-	mgr.queue = append(mgr.queue, event)
-	mgr.queueSync.Unlock()
-}
-
-func (mgr *Manager) CompleteEvent(event LifecycleEvent) {
-	newQueue := make([]LifecycleEvent, 0)
-	for _, e := range mgr.queue {
-		if reflect.DeepEqual(event, e) {
-			log.Debugf("event %v completed processing", event.RequestID)
-		} else {
-			newQueue = append(newQueue, e)
-		}
-	}
-	mgr.queueSync.Lock()
-	mgr.queue = newQueue
-	mgr.completedEvents++
-	mgr.queueSync.Unlock()
 }
 
 type ManagerContext struct {
@@ -107,7 +86,7 @@ func (e *LifecycleEvent) IsValid() bool {
 	return true
 }
 
-func (e *LifecycleEvent) IsAlreadyExist(queue []LifecycleEvent) bool {
+func (e *LifecycleEvent) IsAlreadyExist(queue []*LifecycleEvent) bool {
 	for _, event := range queue {
 		if event.RequestID == e.RequestID {
 			log.Debugf("event %v already being processed, discarding", event.RequestID)


### PR DESCRIPTION
Fixes #5 

This PR fixes bug #5 and also improves overall error handling.
There is now a single method for event failure/success which will handle failure cases.

Now in the case of failure to get the hook name, we will fail the whole event and continue.

### Testing
- Added some unit tests to verify reject/fail handlers.
- Ran manually to verify lifecycle-manager is working as expected