### PR TITLE
Event Publishing

### DIFF
--- a/pkg/service/elb.go
+++ b/pkg/service/elb.go
@@ -41,11 +41,6 @@ func waitForDeregisterInstance(elbClient elbiface.ELBAPI, elbName, instanceID st
 func findInstanceInClassicBalancer(elbClient elbiface.ELBAPI, elbName, instanceID string) (bool, error) {
 	input := &elb.DescribeInstanceHealthInput{
 		LoadBalancerName: aws.String(elbName),
-		Instances: []*elb.Instance{
-			{
-				InstanceId: aws.String(instanceID),
-			},
-		},
 	}
 
 	instance, err := elbClient.DescribeInstanceHealth(input)

--- a/pkg/service/events.go
+++ b/pkg/service/events.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/keikoproj/lifecycle-manager/pkg/log"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type EventReason string
+type EventLevel string
+
+var (
+	// EventName is the default name for service events
+	EventName = "lifecycle-manager.%v"
+	// EventNamespace is the default namespace in which events will be published in
+	EventNamespace = "default"
+
+	EventLevelNormal  = "Normal"
+	EventLevelWarning = "Warning"
+
+	EventReasonLifecycleHookReceived  EventReason = "EventLifecycleHookReceived"
+	EventMessageLifecycleHookReceived             = "lifecycle hook for event %v was received, instance %v will begin processing"
+
+	EventReasonLifecycleHookProcessed  EventReason = "EventLifecycleHookProcessed"
+	EventMessageLifecycleHookProcessed             = "lifecycle hook for event %v has completed processing, instance %v gracefully terminated"
+
+	EventReasonLifecycleHookFailed  EventReason = "EventLifecycleHookFailed"
+	EventMessageLifecycleHookFailed             = "lifecycle hook for event %v has failed processing: %v"
+
+	EventReasonNodeDrainSucceeded  EventReason = "EventReasonNodeDrainSucceeded"
+	EventMessageNodeDrainSucceeded             = "node %v has been drained successfully as a response to a termination event"
+
+	EventReasonNodeDrainFailed  EventReason = "EventReasonNodeDrainFailed"
+	EventMessageNodeDrainFailed             = "node %v draining has failed: %v"
+
+	EventReasonTargetDeregisterSucceeded  EventReason = "EventReasonTargetDeregisterSucceeded"
+	EventMessageTargetDeregisterSucceeded             = "target %v:%v has successfully deregistered from target group %v"
+
+	EventReasonTargetDeregisterFailed  EventReason = "EventReasonTargetDeregisterFailed"
+	EventMessageTargetDeregisterFailed             = "target %v:%v has failed to deregistered from target group %v: %v"
+
+	EventReasonInstanceDeregisterSucceeded  EventReason = "EventReasonInstanceDeregisterSucceeded"
+	EventMessageInstanceDeregisterSucceeded             = "instance %v has successfully deregistered from classic-elb %v"
+
+	EventReasonInstanceDeregisterFailed  EventReason = "EventReasonInstanceDeregisterFailed"
+	EventMessageInstanceDeregisterFailed             = "instance %v has failed to deregistered from classic-elb %v: %v"
+
+	EventLevels = map[EventReason]string{
+		EventReasonLifecycleHookReceived:       EventLevelNormal,
+		EventReasonLifecycleHookProcessed:      EventLevelNormal,
+		EventReasonLifecycleHookFailed:         EventLevelWarning,
+		EventReasonNodeDrainSucceeded:          EventLevelNormal,
+		EventReasonNodeDrainFailed:             EventLevelWarning,
+		EventReasonTargetDeregisterSucceeded:   EventLevelNormal,
+		EventReasonTargetDeregisterFailed:      EventLevelWarning,
+		EventReasonInstanceDeregisterSucceeded: EventLevelNormal,
+		EventReasonInstanceDeregisterFailed:    EventLevelWarning,
+	}
+)
+
+func publishKubernetesEvent(kubeClient kubernetes.Interface, event *v1.Event) {
+	log.Debugf("publishing event: %v", event.Reason)
+	_, err := kubeClient.CoreV1().Events(EventNamespace).Create(event)
+	if err != nil {
+		log.Errorf("failed to publish event: %v", err)
+	}
+}
+
+func getReasonEventLevel(reason EventReason) string {
+	if val, ok := EventLevels[reason]; ok {
+		return val
+	}
+	return "Normal"
+}
+
+func newKubernetesEvent(reason EventReason, message string, refNodeName string) *v1.Event {
+	var objReference v1.ObjectReference
+	if refNodeName != "" {
+		objReference = v1.ObjectReference{Kind: "Node", Name: refNodeName}
+	}
+	event := &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf(EventName, time.Now().UnixNano()),
+			Namespace: EventNamespace,
+		},
+		Reason:  string(reason),
+		Message: string(message),
+		Type:    getReasonEventLevel(reason),
+		LastTimestamp: metav1.Time{
+			Time: time.Now(),
+		},
+		InvolvedObject: objReference,
+	}
+	return event
+}

--- a/pkg/service/events.go
+++ b/pkg/service/events.go
@@ -11,8 +11,54 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// EventReason defines the reason of an event
 type EventReason string
+
+// EventLevel defines the level of an event
 type EventLevel string
+
+const (
+	// EventLevelNormal is the level of a normal event
+	EventLevelNormal = "Normal"
+	// EventLevelWarning is the level of a warning event
+	EventLevelWarning = "Warning"
+	// EventReasonLifecycleHookReceived is the reason for a lifecycle received event
+	EventReasonLifecycleHookReceived EventReason = "EventLifecycleHookReceived"
+	// EventMessageLifecycleHookReceived is the message for a lifecycle received event
+	EventMessageLifecycleHookReceived = "lifecycle hook for event %v was received, instance %v will begin processing"
+	// EventReasonLifecycleHookProcessed is the reason for a lifecycle successful processing event
+	EventReasonLifecycleHookProcessed EventReason = "EventLifecycleHookProcessed"
+	//EventMessageLifecycleHookProcessed is the message for a lifecycle successful processing event
+	EventMessageLifecycleHookProcessed = "lifecycle hook for event %v has completed processing, instance %v gracefully terminated"
+	// EventReasonLifecycleHookFailed is the reason for a lifecycle failed event
+	EventReasonLifecycleHookFailed EventReason = "EventLifecycleHookFailed"
+	// EventMessageLifecycleHookFailed is the message for a lifecycle failed event
+	EventMessageLifecycleHookFailed = "lifecycle hook for event %v has failed processing: %v"
+	// EventReasonNodeDrainSucceeded is the reason for a successful drain event
+	EventReasonNodeDrainSucceeded EventReason = "EventReasonNodeDrainSucceeded"
+	// EventMessageNodeDrainSucceeded is the message for a successful drain event
+	EventMessageNodeDrainSucceeded = "node %v has been drained successfully as a response to a termination event"
+	// EventReasonNodeDrainFailed is the reason for a failed drain event
+	EventReasonNodeDrainFailed EventReason = "EventReasonNodeDrainFailed"
+	// EventMessageNodeDrainFailed is the message for a failed drain event
+	EventMessageNodeDrainFailed = "node %v draining has failed: %v"
+	// EventReasonTargetDeregisterSucceeded is the reason for a successful target group deregister event
+	EventReasonTargetDeregisterSucceeded EventReason = "EventReasonTargetDeregisterSucceeded"
+	// EventMessageTargetDeregisterSucceeded is the message for a successful target group deregister event
+	EventMessageTargetDeregisterSucceeded = "target %v:%v has successfully deregistered from target group %v"
+	// EventReasonTargetDeregisterFailed is the reason for a successful drain event
+	EventReasonTargetDeregisterFailed EventReason = "EventReasonTargetDeregisterFailed"
+	// EventMessageTargetDeregisterFailed is the message for a successful drain event
+	EventMessageTargetDeregisterFailed = "target %v:%v has failed to deregistered from target group %v: %v"
+	// EventReasonInstanceDeregisterSucceeded is the reason for a successful target group deregister event
+	EventReasonInstanceDeregisterSucceeded EventReason = "EventReasonInstanceDeregisterSucceeded"
+	// EventMessageInstanceDeregisterSucceeded is the message for a successful target group deregister event
+	EventMessageInstanceDeregisterSucceeded = "instance %v has successfully deregistered from classic-elb %v"
+	// EventReasonInstanceDeregisterFailed is the reason for a successful classic elb deregister event
+	EventReasonInstanceDeregisterFailed EventReason = "EventReasonInstanceDeregisterFailed"
+	// EventMessageInstanceDeregisterFailed is the message for a successful classic elb deregister event
+	EventMessageInstanceDeregisterFailed = "instance %v has failed to deregistered from classic-elb %v: %v"
+)
 
 var (
 	// EventName is the default name for service events
@@ -20,36 +66,7 @@ var (
 	// EventNamespace is the default namespace in which events will be published in
 	EventNamespace = "default"
 
-	EventLevelNormal  = "Normal"
-	EventLevelWarning = "Warning"
-
-	EventReasonLifecycleHookReceived  EventReason = "EventLifecycleHookReceived"
-	EventMessageLifecycleHookReceived             = "lifecycle hook for event %v was received, instance %v will begin processing"
-
-	EventReasonLifecycleHookProcessed  EventReason = "EventLifecycleHookProcessed"
-	EventMessageLifecycleHookProcessed             = "lifecycle hook for event %v has completed processing, instance %v gracefully terminated"
-
-	EventReasonLifecycleHookFailed  EventReason = "EventLifecycleHookFailed"
-	EventMessageLifecycleHookFailed             = "lifecycle hook for event %v has failed processing: %v"
-
-	EventReasonNodeDrainSucceeded  EventReason = "EventReasonNodeDrainSucceeded"
-	EventMessageNodeDrainSucceeded             = "node %v has been drained successfully as a response to a termination event"
-
-	EventReasonNodeDrainFailed  EventReason = "EventReasonNodeDrainFailed"
-	EventMessageNodeDrainFailed             = "node %v draining has failed: %v"
-
-	EventReasonTargetDeregisterSucceeded  EventReason = "EventReasonTargetDeregisterSucceeded"
-	EventMessageTargetDeregisterSucceeded             = "target %v:%v has successfully deregistered from target group %v"
-
-	EventReasonTargetDeregisterFailed  EventReason = "EventReasonTargetDeregisterFailed"
-	EventMessageTargetDeregisterFailed             = "target %v:%v has failed to deregistered from target group %v: %v"
-
-	EventReasonInstanceDeregisterSucceeded  EventReason = "EventReasonInstanceDeregisterSucceeded"
-	EventMessageInstanceDeregisterSucceeded             = "instance %v has successfully deregistered from classic-elb %v"
-
-	EventReasonInstanceDeregisterFailed  EventReason = "EventReasonInstanceDeregisterFailed"
-	EventMessageInstanceDeregisterFailed             = "instance %v has failed to deregistered from classic-elb %v: %v"
-
+	// EventLevels is a map of event reasons and their event level
 	EventLevels = map[EventReason]string{
 		EventReasonLifecycleHookReceived:       EventLevelNormal,
 		EventReasonLifecycleHookProcessed:      EventLevelNormal,

--- a/pkg/service/events_test.go
+++ b/pkg/service/events_test.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_NewEvent(t *testing.T) {
+	t.Log("Test_NewEvent: should be able to get a new kubernetes event")
+	referencedNode := "ip-10-10-10-10"
+	msg := fmt.Sprintf(EventMessageInstanceDeregisterFailed, "i-123456789012", "my-load-balancer", "some bad error occured")
+	event := newKubernetesEvent(EventReasonInstanceDeregisterFailed, msg, referencedNode)
+
+	if event.Reason != string(EventReasonInstanceDeregisterFailed) {
+		t.Fatalf("expected event.Reason to be: %v, got: %v", string(EventReasonInstanceDeregisterFailed), event.Reason)
+	}
+
+	if event.InvolvedObject.Name != referencedNode {
+		t.Fatalf("expected event.InvolvedObject.Name to be: %v, got: %v", referencedNode, event.InvolvedObject.Name)
+	}
+
+	if event.Message != msg {
+		t.Fatalf("expected event.Message to be: %v, got: %v", msg, event.Message)
+	}
+
+}
+
+func Test_PublishEvent(t *testing.T) {
+	t.Log("Test_PublishEvent: should be able to publish kubernetes events")
+	kubeClient := fake.NewSimpleClientset()
+	referencedNode := "ip-10-10-10-10"
+	msg := fmt.Sprintf(EventMessageInstanceDeregisterFailed, "i-123456789012", "my-load-balancer", "some bad error occured")
+	event := newKubernetesEvent(EventReasonInstanceDeregisterFailed, msg, referencedNode)
+
+	publishKubernetesEvent(kubeClient, event)
+	expectedEvents := 1
+
+	events, err := kubeClient.CoreV1().Events(EventNamespace).List(metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Test_PublishEvent: expected error not to have occured, %v", err)
+	}
+
+	if len(events.Items) != expectedEvents {
+		t.Fatalf("Test_PublishEvent: expected %v events, found: %v", expectedEvents, len(events.Items))
+	}
+}


### PR DESCRIPTION
Fixes #9 

This enables publishing of Kubernetes events for lifecycle hooks

## Testing
Added unit tests and did a full test with large termination activities.


