### PR TITLE
Clear up RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,7 @@ time="2019-10-02T02:44:45Z" level=info msg="sending heartbeat for event with ins
 time="2019-10-02T02:45:15Z" level=info msg="setting lifecycle event as completed with result: 'CONTINUE'"
 ```
 
-### Required AWS Auth / RBAC
-
-#### AWS
+### Required AWS Auth
 
 ```json
 {
@@ -88,23 +86,6 @@ time="2019-10-02T02:45:15Z" level=info msg="setting lifecycle event as completed
     ],
     "Resource": "*"
 }
-```
-
-#### RBAC
-
-```yaml
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["get", "list", "patch"]
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "list"]
-- apiGroups: [""]
-  resources: ["pods/eviction"]
-  verbs: ["create"]
-- apiGroups: ["extensions", "apps"]
-  resources: ["daemonsets"]
-  verbs: ["get"]
 ```
 
 ## Release History

--- a/examples/lifecycle-manager.yaml
+++ b/examples/lifecycle-manager.yaml
@@ -16,16 +16,19 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "patch"]
 - apiGroups: [""]
-  resources: ["events"]
-  verbs: ["get", "list", "create"]
+  resources: ["pods"]
+  verbs: ["get", "list"]
 - apiGroups: [""]
   resources: ["pods/eviction"]
   verbs: ["create"]
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets"]
   verbs: ["get"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
The RBAC in the README.md and in the example yaml doesn't seem to match up. When using the example yaml, lifecycle-manager wasn't able to do certain things it needed to do when I first deployed it. I merged the two sets of RBAC rules in the example yaml and removed the README.md RBAC. Simply pointing people towards the yaml should be sufficient I reckon and keeps things in one place.