### PR TITLE
Add missing serve command

### DIFF
--- a/examples/lifecycle-manager.yaml
+++ b/examples/lifecycle-manager.yaml
@@ -70,8 +70,9 @@ spec:
               memory: 100Mi
           command:
             - /bin/lifecycle-manager
-            - --queue-name lifecycle-manager-queue
-            - --region us-west-2
+            - serve
+            - --queue-name=lifecycle-manager-queue
+            - --region=us-west-2
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
The command specified in the example yaml didn't work out of the box
for me. I added the 'serve' command and had to change the
remaining args to use 'arg=val' notation.