### PR TITLE
lifecycle hook processing duration logging

### DIFF
--- a/pkg/service/events.go
+++ b/pkg/service/events.go
@@ -29,11 +29,11 @@ const (
 	// EventReasonLifecycleHookProcessed is the reason for a lifecycle successful processing event
 	EventReasonLifecycleHookProcessed EventReason = "EventLifecycleHookProcessed"
 	//EventMessageLifecycleHookProcessed is the message for a lifecycle successful processing event
-	EventMessageLifecycleHookProcessed = "lifecycle hook for event %v has completed processing, instance %v gracefully terminated"
+	EventMessageLifecycleHookProcessed = "lifecycle hook for event %v has completed processing, instance %v gracefully terminated after %vs"
 	// EventReasonLifecycleHookFailed is the reason for a lifecycle failed event
 	EventReasonLifecycleHookFailed EventReason = "EventLifecycleHookFailed"
 	// EventMessageLifecycleHookFailed is the message for a lifecycle failed event
-	EventMessageLifecycleHookFailed = "lifecycle hook for event %v has failed processing: %v"
+	EventMessageLifecycleHookFailed = "lifecycle hook for event %v has failed processing after %vs: %v"
 	// EventReasonNodeDrainSucceeded is the reason for a successful drain event
 	EventReasonNodeDrainSucceeded EventReason = "EventReasonNodeDrainSucceeded"
 	// EventMessageNodeDrainSucceeded is the message for a successful drain event

--- a/pkg/service/server_test.go
+++ b/pkg/service/server_test.go
@@ -102,6 +102,7 @@ func Test_FailHandler(t *testing.T) {
 		LifecycleActionToken: "cc34960c-1e41-4703-a665-bdb3e5b81ad3",
 		receiptHandle:        "MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+Cw=",
 		heartbeatInterval:    2,
+		startTime:            time.Now().Add(time.Duration(-1) * time.Second),
 	}
 
 	mgr := New(auth, ctx)

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go/service/elb/elbiface"
 
@@ -69,6 +70,7 @@ type LifecycleEvent struct {
 	drainCompleted       bool
 	deregisterCompleted  bool
 	eventCompleted       bool
+	startTime            time.Time
 }
 
 func (e *LifecycleEvent) IsValid() bool {
@@ -120,3 +122,6 @@ func (e *LifecycleEvent) SetDeregisterCompleted(val bool) { e.deregisterComplete
 
 // SetEventCompleted is a setter method for status of the drain operation
 func (e *LifecycleEvent) SetEventCompleted(val bool) { e.eventCompleted = val }
+
+// SetEventTimeStarted is a setter method for the time an event started
+func (e *LifecycleEvent) SetEventTimeStarted(t time.Time) { e.startTime = t }


### PR DESCRIPTION
Fixes #17 

This adds the seconds that a lifecycle event took to process to both console logging and published kubernetes events.