### PR TITLE
Add jitter between API calls / threads

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -43,7 +43,7 @@ var (
 	DefaultRetryer = client.DefaultRetryer{
 		NumMaxRetries:    250,
 		MinThrottleDelay: time.Second * 5,
-		MaxThrottleDelay: time.Second * 20,
+		MaxThrottleDelay: time.Second * 60,
 		MinRetryDelay:    time.Second * 1,
 		MaxRetryDelay:    time.Second * 5,
 	}

--- a/pkg/service/elb.go
+++ b/pkg/service/elb.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -15,12 +14,10 @@ import (
 func waitForDeregisterInstance(elbClient elbiface.ELBAPI, elbName, instanceID string) error {
 	var (
 		MaxAttempts = 500
-		ConstDelay  = request.ConstantWaiterDelay(10 * time.Second)
 	)
 
 	waiterOpts := []request.WaiterOption{
 		request.WithWaiterMaxAttempts(MaxAttempts),
-		request.WithWaiterDelay(ConstDelay),
 	}
 	input := &elb.DescribeInstanceHealthInput{
 		LoadBalancerName: aws.String(elbName),

--- a/pkg/service/elbv2.go
+++ b/pkg/service/elbv2.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -15,13 +14,12 @@ import (
 func waitForDeregisterTarget(elbClient elbv2iface.ELBV2API, arn, instanceID string, port int64) error {
 	var (
 		MaxAttempts = 500
-		ConstDelay  = request.ConstantWaiterDelay(10 * time.Second)
 	)
 
 	waiterOpts := []request.WaiterOption{
 		request.WithWaiterMaxAttempts(MaxAttempts),
-		request.WithWaiterDelay(ConstDelay),
 	}
+
 	input := &elbv2.DescribeTargetHealthInput{
 		TargetGroupArn: aws.String(arn),
 		Targets: []*elbv2.TargetDescription{
@@ -31,6 +29,7 @@ func waitForDeregisterTarget(elbClient elbv2iface.ELBV2API, arn, instanceID stri
 			},
 		},
 	}
+
 	err := elbClient.WaitUntilTargetDeregisteredWithContext(context.Background(), input, waiterOpts...)
 	if err != nil {
 		return err
@@ -45,7 +44,7 @@ func findInstanceInTargetGroup(elbClient elbv2iface.ELBV2API, arn, instanceID st
 
 	target, err := elbClient.DescribeTargetHealth(input)
 	if err != nil {
-	        log.Infof("failed finding instance %v in target group %v: %v", instanceID, arn, err.Error())
+		log.Infof("failed finding instance %v in target group %v: %v", instanceID, arn, err.Error())
 		return false, 0, err
 	}
 	for _, desc := range target.TargetHealthDescriptions {

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -367,7 +367,7 @@ func (mgr *Manager) drainLoadbalancerTarget(event *LifecycleEvent) error {
 	// create goroutine per target group with target match
 	wg.Add(workQueueLength)
 
-	// sleep for random 0-180 seconds to goroutine
+	// sleep for random jitter per goroutine
 	waitJitter(ThreadJitterRangeSeconds)
 
 	// handle classic load balancers

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -130,7 +130,6 @@ func (mgr *Manager) FailEvent(err error, event *LifecycleEvent, abandon bool) {
 	)
 	log.Errorf("event %v has failed processing after %vs: %v", event.RequestID, t, err)
 	mgr.failedEvents++
-	event.SetEventCompleted(true)
 	msg := fmt.Sprintf(EventMessageLifecycleHookFailed, event.RequestID, t, err)
 	publishKubernetesEvent(kubeClient, newKubernetesEvent(EventReasonLifecycleHookFailed, msg, event.referencedNode.Name))
 

--- a/pkg/service/server_test.go
+++ b/pkg/service/server_test.go
@@ -16,6 +16,11 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+func init() {
+	ThreadJitterRangeSeconds = 1
+	DeregisterJitterRangeSeconds = 1
+}
+
 func Test_RejectHandler(t *testing.T) {
 	t.Log("Test_RejectHandler: should handle rejections")
 	var (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,13 +7,13 @@ github.com/aws/aws-sdk-go/aws/request
 github.com/aws/aws-sdk-go/aws/session
 github.com/aws/aws-sdk-go/service/autoscaling
 github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface
+github.com/aws/aws-sdk-go/service/elb
+github.com/aws/aws-sdk-go/service/elb/elbiface
 github.com/aws/aws-sdk-go/service/elbv2
 github.com/aws/aws-sdk-go/service/elbv2/elbv2iface
 github.com/aws/aws-sdk-go/service/sqs
 github.com/aws/aws-sdk-go/service/sqs/sqsiface
 github.com/aws/aws-sdk-go/aws/awserr
-github.com/aws/aws-sdk-go/service/elb
-github.com/aws/aws-sdk-go/service/elb/elbiface
 github.com/aws/aws-sdk-go/aws/credentials
 github.com/aws/aws-sdk-go/aws/endpoints
 github.com/aws/aws-sdk-go/internal/sdkio


### PR DESCRIPTION
Fixes #22 

This PR introduces Jitter at two locations:
- Spawning of main worker go routine thread
- Each iteration of deregister

In addition to jitter, for deregister calls we remove the ContsantDelay and fall back to exponential backoff which will now range from 5-60 seconds.

Tested this change vs. 0.3.0 with a cluster scaling down 20 instances and 10 target groups.

Throttling messages went from 2K to 200~.
Time to process events was between 350s to 400s.
