### PR TITLE
JSON payload inside message field of v1.Event

### DIFF
--- a/.github/DEVELOPER.md
+++ b/.github/DEVELOPER.md
@@ -7,6 +7,7 @@ This document will also assume a running Kubernetes cluster on AWS.
 
 You can run the `main.go` file with the appropriate command line arguments to invoke lifecycle-manager locally.
 The `--local-mode` flag tells lifecycle-manager to use a local kubeconfig from the provided path instead of `InClusterAuth`.
+You might want to export/set AWS credentials or profile if you are running in local mode.
 
 Make sure you already have an autoscaling group configured to post lifecycle hooks to an SQS queue.
 

--- a/pkg/service/elbv2.go
+++ b/pkg/service/elbv2.go
@@ -45,7 +45,7 @@ func findInstanceInTargetGroup(elbClient elbv2iface.ELBV2API, arn, instanceID st
 
 	target, err := elbClient.DescribeTargetHealth(input)
 	if err != nil {
-	        log.Infof("failed finding instance %v in target group %v: %v", instanceID, arn, err.Error())
+		log.Infof("failed finding instance %v in target group %v: %v", instanceID, arn, err.Error())
 		return false, 0, err
 	}
 	for _, desc := range target.TargetHealthDescriptions {

--- a/pkg/service/events.go
+++ b/pkg/service/events.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -95,18 +96,29 @@ func getReasonEventLevel(reason EventReason) string {
 	return "Normal"
 }
 
-func newKubernetesEvent(reason EventReason, message string, refNodeName string) *v1.Event {
+// FIXME: msgFields should be map[string]string
+func newKubernetesEvent(reason EventReason, msgFields interface{}, refNodeName string) *v1.Event {
 	var objReference v1.ObjectReference
 	if refNodeName != "" {
 		objReference = v1.ObjectReference{Kind: "Node", Name: refNodeName}
 	}
+
+	// Marshal as JSON
+	b, err := json.Marshal(msgFields)
+	msgPayload := string(b)
+	if err != nil {
+		log.Errorf("json.Marshal Failed, %s", err)
+		// let's convert map to string since encoding as JSON is failing. At the least the information will be conveyed
+		msgPayload = fmt.Sprintf("%v", msgFields)
+	}
+
 	event := &v1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf(EventName, time.Now().UnixNano()),
 			Namespace: EventNamespace,
 		},
 		Reason:  string(reason),
-		Message: string(message),
+		Message: msgPayload,
 		Type:    getReasonEventLevel(reason),
 		LastTimestamp: metav1.Time{
 			Time: time.Now(),

--- a/pkg/service/events.go
+++ b/pkg/service/events.go
@@ -96,8 +96,7 @@ func getReasonEventLevel(reason EventReason) string {
 	return "Normal"
 }
 
-// FIXME: msgFields should be map[string]string
-func newKubernetesEvent(reason EventReason, msgFields interface{}, refNodeName string) *v1.Event {
+func newKubernetesEvent(reason EventReason, msgFields map[string]string, refNodeName string) *v1.Event {
 	var objReference v1.ObjectReference
 	if refNodeName != "" {
 		objReference = v1.ObjectReference{Kind: "Node", Name: refNodeName}
@@ -106,6 +105,8 @@ func newKubernetesEvent(reason EventReason, msgFields interface{}, refNodeName s
 	// Marshal as JSON
 	b, err := json.Marshal(msgFields)
 	msgPayload := string(b)
+	// I think it is very tough to trigger this error since json.Marshal function can return two types of errors
+	// UnsupportedTypeError or UnsupportedValueError. Since our type is very rigid, these errors won't be triggered.
 	if err != nil {
 		log.Errorf("json.Marshal Failed, %s", err)
 		// let's convert map to string since encoding as JSON is failing. At the least the information will be conveyed

--- a/pkg/service/events_test.go
+++ b/pkg/service/events_test.go
@@ -12,11 +12,11 @@ import (
 func Test_NewEvent(t *testing.T) {
 	t.Log("Test_NewEvent: should be able to get a new kubernetes event")
 	referencedNode := "ip-10-10-10-10"
-	msg := fmt.Sprintf(EventMessageInstanceDeregisterFailed, "i-123456789012", "my-load-balancer", "some bad error occured")
+	msg := fmt.Sprintf(EventMessageInstanceDeregisterFailed, "i-123456789012", "my-load-balancer", "some bad error occurred")
 	msgFields := map[string]string{
 		"ec2InstanceId": "i-123456789012",
 		"loadBalancer":  "my-load-balancer",
-		"error":         "some bad error occured",
+		"error":         "some bad error occurred",
 		"details":       msg,
 	}
 	event := newKubernetesEvent(EventReasonInstanceDeregisterFailed, msgFields, referencedNode)
@@ -46,11 +46,11 @@ func Test_PublishEvent(t *testing.T) {
 	t.Log("Test_PublishEvent: should be able to publish kubernetes events")
 	kubeClient := fake.NewSimpleClientset()
 	referencedNode := "ip-10-10-10-10"
-	msg := fmt.Sprintf(EventMessageInstanceDeregisterFailed, "i-123456789012", "my-load-balancer", "some bad error occured")
+	msg := fmt.Sprintf(EventMessageInstanceDeregisterFailed, "i-123456789012", "my-load-balancer", "some bad error occurred")
 	msgFields := map[string]string{
 		"ec2InstanceId": "i-123456789012",
 		"loadBalancer":  "my-load-balancer",
-		"error":         "some bad error occured",
+		"error":         "some bad error occurred",
 		"details":       msg,
 	}
 	event := newKubernetesEvent(EventReasonInstanceDeregisterFailed, msgFields, referencedNode)
@@ -66,4 +66,18 @@ func Test_PublishEvent(t *testing.T) {
 	if len(events.Items) != expectedEvents {
 		t.Fatalf("Test_PublishEvent: expected %v events, found: %v", expectedEvents, len(events.Items))
 	}
+
+	// decode the JSON
+	var msgPayload map[string]string
+	err = json.Unmarshal([]byte(event.Message), &msgPayload)
+	if err != nil {
+		t.Fatalf("json.Unmarshal Failed, %s", err)
+	}
+	if msgPayload["ec2InstanceId"] != "i-123456789012" {
+		t.Fatalf("Expected=%s, Got=%s", "i-123456789012", msgPayload["ec2InstanceId"])
+	}
+	if msg != msgPayload["details"] {
+		t.Fatalf("expected event.Message to be: %v, got: %v", msg, msgPayload["details"])
+	}
+
 }

--- a/pkg/service/server_test.go
+++ b/pkg/service/server_test.go
@@ -344,6 +344,196 @@ func Test_HandleEventWithDeregister(t *testing.T) {
 	}
 }
 
+func Test_HandleEventWithDeregisterError(t *testing.T) {
+	t.Log("Test_HandleEvent: should successfully handle events")
+	var (
+		asgStubber       = &stubAutoscaling{}
+		sqsStubber       = &stubSQS{}
+		arn              = "arn:aws:elasticloadbalancing:us-west-2:0000000000:targetgroup/targetgroup-name/some-id"
+		elbName          = "my-classic-elb"
+		instanceID       = "i-123486890234"
+		port       int64 = 122233
+	)
+
+	elbv2Stubber := &stubErrorELBv2{
+		targetHealthDescriptions: []*elbv2.TargetHealthDescription{
+			{
+				Target: &elbv2.TargetDescription{
+					Id:   aws.String(instanceID),
+					Port: aws.Int64(port),
+				},
+			},
+		},
+		targetGroups: []*elbv2.TargetGroup{
+			{
+				TargetGroupArn: aws.String(arn),
+			},
+		},
+		failHint: "DeregisterTargets",
+	}
+
+	elbStubber := &stubErrorELB{
+		loadBalancerDescriptions: []*elb.LoadBalancerDescription{
+			{
+				LoadBalancerName: aws.String(elbName),
+			},
+		},
+		instanceStates: []*elb.InstanceState{
+			{
+				InstanceId: aws.String(instanceID),
+			},
+		},
+		failHint: "DeregisterInstancesFromLoadBalancer",
+	}
+
+	auth := Authenticator{
+		ScalingGroupClient: asgStubber,
+		SQSClient:          sqsStubber,
+		ELBv2Client:        elbv2Stubber,
+		ELBClient:          elbStubber,
+		KubernetesClient:   fake.NewSimpleClientset(),
+	}
+
+	ctx := ManagerContext{
+		KubectlLocalPath:       stubKubectlPathSuccess,
+		QueueName:              "my-queue",
+		Region:                 "us-west-2",
+		DrainTimeoutSeconds:    1,
+		PollingIntervalSeconds: 1,
+		WithDeregister:         true,
+	}
+
+	fakeNodes := []v1.Node{
+		{
+			Spec: v1.NodeSpec{
+				ProviderID: fmt.Sprintf("aws:///us-west-2a/%v", instanceID),
+			},
+		},
+		{
+			Spec: v1.NodeSpec{
+				ProviderID: "aws:///us-west-2c/i-22222222222222222",
+			},
+		},
+	}
+
+	for _, node := range fakeNodes {
+		auth.KubernetesClient.CoreV1().Nodes().Create(&node)
+	}
+
+	event := &LifecycleEvent{
+		LifecycleHookName:    "my-hook",
+		AccountID:            "12345689012",
+		RequestID:            "63f5b5c2-58b3-0574-b7d5-b3162d0268f0",
+		LifecycleTransition:  "autoscaling:EC2_INSTANCE_TERMINATING",
+		AutoScalingGroupName: "my-asg",
+		EC2InstanceID:        instanceID,
+		LifecycleActionToken: "cc34960c-1e41-4703-a665-bdb3e5b81ad3",
+		receiptHandle:        "MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+Cw=",
+		heartbeatInterval:    3,
+	}
+
+	g := New(auth, ctx)
+	err := g.handleEvent(event)
+	if err == nil {
+		t.Fatalf("handleEvent: expected error but did not get an error")
+	}
+}
+
+func Test_HandleEventWaitUntilTargetDeregisterError(t *testing.T) {
+	t.Log("Test_HandleEvent: should successfully handle events")
+	var (
+		asgStubber       = &stubAutoscaling{}
+		sqsStubber       = &stubSQS{}
+		arn              = "arn:aws:elasticloadbalancing:us-west-2:0000000000:targetgroup/targetgroup-name/some-id"
+		elbName          = "my-classic-elb"
+		instanceID       = "i-123486890234"
+		port       int64 = 122233
+	)
+
+	elbv2Stubber := &stubErrorELBv2{
+		targetHealthDescriptions: []*elbv2.TargetHealthDescription{
+			{
+				Target: &elbv2.TargetDescription{
+					Id:   aws.String(instanceID),
+					Port: aws.Int64(port),
+				},
+			},
+		},
+		targetGroups: []*elbv2.TargetGroup{
+			{
+				TargetGroupArn: aws.String(arn),
+			},
+		},
+		failHint: "WaitUntilTargetDeregisteredWithContext",
+	}
+
+	elbStubber := &stubErrorELB{
+		loadBalancerDescriptions: []*elb.LoadBalancerDescription{
+			{
+				LoadBalancerName: aws.String(elbName),
+			},
+		},
+		instanceStates: []*elb.InstanceState{
+			{
+				InstanceId: aws.String(instanceID),
+			},
+		},
+		failHint: "WaitUntilInstanceDeregisteredWithContext",
+	}
+
+	auth := Authenticator{
+		ScalingGroupClient: asgStubber,
+		SQSClient:          sqsStubber,
+		ELBv2Client:        elbv2Stubber,
+		ELBClient:          elbStubber,
+		KubernetesClient:   fake.NewSimpleClientset(),
+	}
+
+	ctx := ManagerContext{
+		KubectlLocalPath:       stubKubectlPathSuccess,
+		QueueName:              "my-queue",
+		Region:                 "us-west-2",
+		DrainTimeoutSeconds:    1,
+		PollingIntervalSeconds: 1,
+		WithDeregister:         true,
+	}
+
+	fakeNodes := []v1.Node{
+		{
+			Spec: v1.NodeSpec{
+				ProviderID: fmt.Sprintf("aws:///us-west-2a/%v", instanceID),
+			},
+		},
+		{
+			Spec: v1.NodeSpec{
+				ProviderID: "aws:///us-west-2c/i-22222222222222222",
+			},
+		},
+	}
+
+	for _, node := range fakeNodes {
+		auth.KubernetesClient.CoreV1().Nodes().Create(&node)
+	}
+
+	event := &LifecycleEvent{
+		LifecycleHookName:    "my-hook",
+		AccountID:            "12345689012",
+		RequestID:            "63f5b5c2-58b3-0574-b7d5-b3162d0268f0",
+		LifecycleTransition:  "autoscaling:EC2_INSTANCE_TERMINATING",
+		AutoScalingGroupName: "my-asg",
+		EC2InstanceID:        instanceID,
+		LifecycleActionToken: "cc34960c-1e41-4703-a665-bdb3e5b81ad3",
+		receiptHandle:        "MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+Cw=",
+		heartbeatInterval:    3,
+	}
+
+	g := New(auth, ctx)
+	err := g.handleEvent(event)
+	if err == nil {
+		t.Fatalf("handleEvent: expected error but did not get an error")
+	}
+}
+
 func Test_Poller(t *testing.T) {
 	t.Log("Test_Poller: should deliver messages from sqs to channel")
 	var (


### PR DESCRIPTION
fixes #24 

An example run looks something like this

```
$ k -n default get events -w
+ kubectl -n default get events -w
LAST SEEN   TYPE     REASON                          OBJECT                                              MESSAGE
53s         Normal   EventLifecycleHookReceived      node/ip-10-129-162-131.us-west-2.compute.internal   {"asgName":"iks-system.mpa-play-1.k8s.local","details":"lifecycle hook for event 9ca5bab9-fc84-92be-b133-bbe3dd6e8a30 was received, instance i-05faf90edc56de7d0 will begin processing","ec2InstanceId":"i-05faf90edc56de7d0","eventID":"9ca5bab9-fc84-92be-b133-bbe3dd6e8a30"}
49s         Normal   EventReasonNodeDrainSucceeded   node/ip-10-129-162-131.us-west-2.compute.internal   {"asgName":"iks-system.mpa-play-1.k8s.local","details":"node ip-10-129-162-131.us-west-2.compute.internal has been drained successfully as a response to a termination event","ec2InstanceId":"i-05faf90edc56de7d0","eventID":"9ca5bab9-fc84-92be-b133-bbe3dd6e8a30"}
```