### PR TITLE
add Kind, firsttimestamp and count to v1.Event

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -29,7 +29,7 @@ func newKubernetesClient(localMode string) *kubernetes.Clientset {
 		// use kubeconfig
 		config, err = clientcmd.BuildConfigFromFlags("", localMode)
 		if err != nil {
-			log.Fatalf("cannot load kubernetes config from '%v'", localMode)
+			log.Fatalf("cannot load kubernetes config from '%v', Err=%s", localMode, err)
 		}
 	} else {
 		// use InCluster auth

--- a/pkg/service/events.go
+++ b/pkg/service/events.go
@@ -119,17 +119,22 @@ func newKubernetesEvent(reason EventReason, msgFields map[string]string) *v1.Eve
 	}
 
 	eventName := fmt.Sprintf("%v-%v.%v", "lifecycle-manager", time.Now().Unix(), rand.Int())
+	t := metav1.Time{Time: time.Now()}
 	event := &v1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      eventName,
 			Namespace: EventNamespace,
 		},
-		Reason:  string(reason),
-		Message: msgPayload,
-		Type:    getReasonEventLevel(reason),
-		LastTimestamp: metav1.Time{
-			Time: time.Now(),
+		InvolvedObject: v1.ObjectReference{
+			Kind:      "LifecycleManager",
+			Namespace: EventNamespace,
 		},
+		Reason:         string(reason),
+		Message:        msgPayload,
+		Type:           getReasonEventLevel(reason),
+		Count:          1,
+		FirstTimestamp: t,
+		LastTimestamp:  t,
 	}
 	return event
 }


### PR DESCRIPTION
* log error if `localmode` is pointing to erroneous config file
* add `Kind` to v1.Event
* set firsttimestamp and count in v1.Event

### log
```
INFO[0084] deregistrator> no active targets for deregistration 
INFO[0085] event e285c95b-42fb-f2b6-fe20-024df0f6d7e8 completed processing 
INFO[0086] i-003caf2e52c34fb3e> setting lifecycle event as completed with result: CONTINUE 
INFO[0086] event e285c95b-42fb-f2b6-fe20-024df0f6d7e8 for instance i-003caf2e52c34fb3e completed after 9.659177478s 
```

### get events
```
3m24s       Normal   LifecycleHookReceived                                                                                        lifecyclemanager                                    {"asgName":"mpa-eks-play2-instance-manager-nodes","details":"lifecycle hook for event e285c95b-42fb-f2b6-fe20-024df0f6d7e8 was received, instance i-003caf2e52c34fb3e will begin processing","ec2InstanceId":"i-003caf2e52c34fb3e","eventID":"e285c95b-42fb-f2b6-fe20-024df0f6d7e8"}
3m19s       Normal   NodeDrainSucceeded                                                                                           lifecyclemanager                                    {"asgName":"mpa-eks-play2-instance-manager-nodes","details":"node ip-10-233-245-169.us-west-2.compute.internal has been drained successfully as a response to a termination event","ec2InstanceId":"i-003caf2e52c34fb3e","eventID":"e285c95b-42fb-f2b6-fe20-024df0f6d7e8"}
3m13s       Normal   LifecycleHookProcessed                                                                                       lifecyclemanager                                    {"asgName":"mpa-eks-play2-instance-manager-nodes","details":"lifecycle hook for event e285c95b-42fb-f2b6-fe20-024df0f6d7e8 has completed processing, instance i-003caf2e52c34fb3e gracefully terminated after 9.659177478s","ec2InstanceId":"i-003caf2e52c34fb3e","eventID":"e285c95b-42fb-f2b6-fe20-024df0f6d7e8"}
```