### PR TITLE
Upgrade kubectl binary to v1.16.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /go/src/github.com/keikoproj/lifecycle-manager
 COPY . .
 
 RUN apk update && apk add --no-cache build-base make git ca-certificates && update-ca-certificates
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.12.3/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.16.15/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 RUN chmod 777 /usr/local/bin/kubectl
 RUN make build
 


### PR DESCRIPTION
Using kubectl 1.12 with clusters >= 1.16 results in DaemonSets not being
handled properly during drains, due to the removal of several deprecated
API versions for DaemonSets. kubectl 1.16 uses the stable API for
DaemonSets, which fixes this issue.

Resolves #59