### PR TITLE
Handle in-progress events without deadlocking

### DIFF
--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -86,7 +86,14 @@ func (mgr *Manager) Start() {
 		if err != nil {
 			log.Errorf("failed to resume in progress events: %v", err)
 		}
-		mgr.eventStream <- message
+
+		event, err := mgr.newEvent(message, queueURL)
+		if err != nil {
+			mgr.RejectEvent(err, event)
+			continue
+		}
+
+		go mgr.Process(event)
 	}
 
 	// start SQS poller to load messages to stream from SQS


### PR DESCRIPTION
When in-progress messages are sent to the eventStream channel,
lifecycle-manager deadlocks, since there are no eventStream receivers
running in a separate goroutine. Instead of sending the in-progress
messages to the eventStream channel, we can process them immediately as
we process SQS-driven events, avoiding the deadlock.

Resolves #62 