### PR TITLE
Prevent conflicts when running multiple lifecycle-managers

### DIFF
--- a/pkg/service/nodes_test.go
+++ b/pkg/service/nodes_test.go
@@ -113,7 +113,8 @@ func Test_GetNodesByAnnotationKey(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node-1",
 				Annotations: map[string]string{
-					"some-key": "some-value",
+					"some-key":    "some-value",
+					"another-key": "another-value",
 				},
 			},
 			Spec: v1.NodeSpec{
@@ -124,7 +125,8 @@ func Test_GetNodesByAnnotationKey(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node-2",
 				Annotations: map[string]string{
-					"some-other-key": "some-value",
+					"some-other-key":    "some-value",
+					"another-other-key": "another-value",
 				},
 			},
 			Spec: v1.NodeSpec{
@@ -137,9 +139,12 @@ func Test_GetNodesByAnnotationKey(t *testing.T) {
 		kubeClient.CoreV1().Nodes().Create(&node)
 	}
 
-	result, err := getNodesByAnnotationKey(kubeClient, "some-key")
-	expected := map[string]string{
-		"node-1": "some-value",
+	result, err := getNodesByAnnotationKeys(kubeClient, "some-key", "another-key")
+	expected := map[string]map[string]string{
+		"node-1": {
+			"some-key":    "some-value",
+			"another-key": "another-value",
+		},
 	}
 
 	if err != nil {


### PR DESCRIPTION
# Description

No argument or functionality changes. This is an internal machinery change that annotates `Node` objects with another annotation (in addition to the original in-progress annotation) that signifies the SQS queue name that the Node's lifecycle is being managed by.

Code changes were done to keep the atomicity of annotation create/delete to avoid inconsistent states when a lifecycle-manager shutdown could otherwise occur between API requests.

This allows us to run two instances of lifecycle-manager as our clusters have more than one underlying Node hardware with different draining and termination SLAs. Previsouly, on startup lifecycle-manager would "claim" all Nodes with the in-progress annotation and start enforcing its drain-timeouts upon them. This was causing unexpected behavior when more than one was running and in the process of draining a node one of the lifecycle-manager Pods got evicted and subsequently took over the Nodes' lifecycles.

As we differentiate our Node types and ASGs using different queues, the queue name seemed like the best item to annotate with so that lifecycle-manager can self-select Nodes on startup that it should be responsible for. In the event that only one lifecycle-manager is running in a cluster, this should behave as expected.

The only caveat I can think of is if you change the queue name you use for Node lifecycles on the ASG but do not update the lifecycle manager before hand.