### PR TITLE
Exclude nodes from external load balancers in Kubernetes 1.19

### DIFF
--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -27,9 +27,13 @@ var (
 	ContinueAction = "CONTINUE"
 	// AbandonAction is the name of the action in case we are unsuccessful in draining
 	AbandonAction = "ABANDON"
-	// ExcludeLabelKey is the alb-ingress-controller exclude label key
-	ExcludeLabelKey = "alpha.service-controller.kubernetes.io/exclude-balancer"
-	// ExcludeLabelValue is the alb-ingress-controller exclude label value
+	// AlphaExcludeLabelKey is the alb-ingress-controller exclude label key
+	AlphaExcludeLabelKey = "alpha.service-controller.kubernetes.io/exclude-balancer"
+	// AlphaExcludeLabelValue is the alb-ingress-controller exclude label value
+	AlphaExcludeLabelValue = "true"
+	// ExcludeLabelKey is the ServiceNodeExclusion feature exclude label key
+	ExcludeLabelKey = "node.kubernetes.io/exclude-from-external-load-balancers"
+	// ExcludeLabelKey is the ServiceNodeExclusion feature exclude label value
 	ExcludeLabelValue = "true"
 	// InProgressAnnotationKey is the annotation key for setting the state of a node to in-progress
 	InProgressAnnotationKey = "lifecycle-manager.keikoproj.io/in-progress"
@@ -481,6 +485,10 @@ func (mgr *Manager) drainLoadbalancerTarget(event *LifecycleEvent) error {
 	// add exclusion label
 	log.Debugf("%v> excluding node %v from load balancers", instanceID, node.Name)
 	err := labelNode(ctx.KubectlLocalPath, node.Name, ExcludeLabelKey, ExcludeLabelValue)
+	if err != nil {
+		return err
+	}
+	err = labelNode(ctx.KubectlLocalPath, node.Name, AlphaExcludeLabelKey, AlphaExcludeLabelValue)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Starting in Kubernetes 1.19, unschedulable nodes were included in load balancers again (see kubernetes/kubernetes#90823), which causes a conflict between the cloud controller and lifecycle-manager, where lifecycle-manager attempts to remove the instance from the load balancer, but then the cloud controller attempts to re-add it.

Kubernetes 1.19 also moved the `ServiceNodeExclusion` feature gate to beta support, and defaults it to enabled, so you can set the `node.kubernetes.io/exclude-from-external-load-balancers` label on the node to have the node be excluded. An older version of this feature used the `alpha.service-controller.kubernetes.io/exclude-balancer`, but this label is removed in Kubernetes 1.19.

This commit sets the new `node.kubernetes.io/exclude-from-external-load-balancers` label in addition to the older alpha label so lifecycle-manager continues to work on both old and new clusters.