### PR TITLE
Update builders

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "direct"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "golang"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -10,24 +10,26 @@ jobs:
   push:
     name: push
     if: github.repository_owner == 'keikoproj'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.3.0
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
       with:
         install: true
         version: latest
 
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
+
     - name: Set up QEMU
       id: qemu
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
       with:
-        image: tonistiigi/binfmt:latest
         platforms: all
 
     - name: Login to DockerHub

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -10,21 +10,22 @@ jobs:
   unit-test:
     if: github.repository_owner == 'keikoproj'
     name: unit-test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ^1.17
+        cache: true
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.3.0
 
     - name: Test
       run: |
         make test
 
     - name: Upload to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
-        file: ./coverage.txt 
+        file: ./coverage.txt

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ cover.html
 bin
 bin/*
 .DS_Store
+.idea
+.tool-versions

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ IMAGE_NAME ?= keikoproj/lifecycle-manager:latest
 TARGETOS ?= linux
 TARGETARCH ?= amd64
 LDFLAGS=-ldflags "-X github.com/keikoproj/lifecycle-manager/version.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -X github.com/keikoproj/lifecycle-manager/version.BuildDate=${BUILD_DATE}"
+TEST_FLAGS ?=
 
 default: test
 
@@ -44,11 +45,9 @@ docker-push:
 clean:
 	@test ! -e bin/${BIN_NAME} || rm bin/${BIN_NAME}
 
-vtest:
-	go test ./... -timeout 30s -v -coverprofile ./coverage.txt
-	go tool cover -html=./coverage.txt -o cover.html
+vtest: TEST_FLAGS += -v
 
-test:
-	go test ./... -timeout 30s -coverprofile ./coverage.txt
+test vtest:
+	go test ./... $(TEST_FLAGS) -timeout 30s -coverprofile ./coverage.txt
 	go tool cover -html=./coverage.txt -o cover.html
 


### PR DESCRIPTION
Fixes #95 

- Cleanup `Makefile`.
- Updates builders to use `ubuntu-latest`.
- Add `dependabot.yml`
- Ignore IDE files.