### PR TITLE
Build updates, dependabot + GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     allow:
       - dependency-type: "direct"
     ignore:
+      - dependency-name: "k8s.io*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
   - package-ecosystem: "docker"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3
 
     - name: Set up Docker Buildx
       id: buildx

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -19,7 +19,7 @@ jobs:
         cache: true
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3
 
     - name: Test
       run: |


### PR DESCRIPTION
- Ignores major,minor updates for kubernetes libs (k8s.io).
- Updated `actions/checkout@v3` to use base version.