### PR TITLE
Release 0.6.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.0
+
++ Bug fix: Allow drain retries even with timeout failures (#104)
++ Package version update: Update docker actions to v4 (#106)
++ Package version update: Build updates, dependabot + GH Actions (#103)
++ Deperecate: Cleanup vendors (#94)
++ Package version update: Bump docker/login-action from 1 to 2 (#97)
++ Package version update: Update builders (#96)
+
 ## 0.5.1
 
 + Support cross-compliation for arm (#76)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/keikoproj/lifecycle-manager.svg?branch=master)](https://travis-ci.org/keikoproj/lifecycle-manager)
 [![codecov](https://codecov.io/gh/keikoproj/lifecycle-manager/branch/master/graph/badge.svg)](https://codecov.io/gh/keikoproj/lifecycle-manager)
 [![Go Report Card](https://goreportcard.com/badge/github.com/keikoproj/lifecycle-manager)](https://goreportcard.com/report/github.com/keikoproj/lifecycle-manager)
-![version](https://img.shields.io/badge/version-0.5.1-green.svg?cacheSeconds=2592000)
+![version](https://img.shields.io/badge/version-0.6.0-green.svg?cacheSeconds=2592000)
 > Graceful AWS scaling event on Kubernetes using lifecycle hooks
 
 lifecycle-manager is a service that can be deployed to a Kubernetes cluster in order to make AWS autoscaling events more graceful using draining

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,7 +9,7 @@ import (
 var GitCommit string
 
 // The main version number that is being run at the moment.
-const Version = "0.5.1"
+const Version = "0.6.0"
 
 var BuildDate = ""
 


### PR DESCRIPTION
## 0.6.0

+ Bug fix: Allow drain retries even with timeout failures (#104)
+ Package version update: Update docker actions to v4 (#106)
+ Package version update: Build updates, dependabot + GH Actions (#103)
+ Deperecate: Cleanup vendors (#94)
+ Package version update: Bump docker/login-action from 1 to 2 (#97)
+ Package version update: Update builders (#96)