### PR TITLE
node deletion

### DIFF
--- a/pkg/service/events.go
+++ b/pkg/service/events.go
@@ -46,6 +46,14 @@ const (
 	EventReasonNodeDrainFailed EventReason = "NodeDrainFailed"
 	// EventMessageNodeDrainFailed is the message for a failed drain event
 	EventMessageNodeDrainFailed = "node %v draining has failed: %v"
+	// EventReasonNodeDeleteSucceeded is the reason for a successful node delete event
+	EventReasonNodeDeleteSucceeded EventReason = "NodeDeleteSucceeded"
+	// EventMessageNodeDeleteSucceeded is the message for a successful node delete event
+	EventMessageNodeDeleteSucceeded = "node %v has been deleted successfully as a response to a termination event"
+	// EventReasonNodeDeletenFailed is the reason for a failed node delete event
+	EventReasonNodeDeleteFailed EventReason = "NodeDeleteFailed"
+	// EventMessageNodeDeleteFailed is the message for a failed node delete event
+	EventMessageNodeDeleteFailed = "node %v deletion has failed: %v"
 	// EventReasonTargetDeregisterSucceeded is the reason for a successful target group deregister event
 	EventReasonTargetDeregisterSucceeded EventReason = "TargetDeregisterSucceeded"
 	// EventMessageTargetDeregisterSucceeded is the message for a successful target group deregister event

--- a/pkg/service/lifecycle.go
+++ b/pkg/service/lifecycle.go
@@ -20,6 +20,7 @@ type LifecycleEvent struct {
 	heartbeatInterval    int64
 	referencedNode       v1.Node
 	drainCompleted       bool
+	nodeDeleted          bool
 	deregisterCompleted  bool
 	eventCompleted       bool
 	startTime            time.Time
@@ -43,6 +44,9 @@ func (e *LifecycleEvent) SetReferencedNode(node v1.Node) { e.referencedNode = no
 
 // SetDrainCompleted is a setter method for status of the drain operation
 func (e *LifecycleEvent) SetDrainCompleted(val bool) { e.drainCompleted = val }
+
+// SetNodeDeleted is a setter method for status of the node deletion operation
+func (e *LifecycleEvent) SetNodeDeleted(val bool) { e.nodeDeleted = val }
 
 // SetDeregisterCompleted is a setter method for status of the drain operation
 func (e *LifecycleEvent) SetDeregisterCompleted(val bool) { e.deregisterCompleted = val }

--- a/pkg/service/metrics.go
+++ b/pkg/service/metrics.go
@@ -26,9 +26,11 @@ const (
 	SuccessfulEventsTotalMetric       = "successful_events_total"
 	SuccessfulLBDeregisterTotalMetric = "successful_lb_deregister_total"
 	SuccessfulNodeDrainTotalMetric    = "successful_node_drain_total"
+	SuccessfulNodeDeleteTotalMetric   = "successful_node_delete_total"
 	FailedEventsTotalMetric           = "failed_events_total"
 	FailedLBDeregisterTotalMetric     = "failed_lb_deregister_total"
 	FailedNodeDrainTotalMetric        = "failed_node_drain_total"
+	FailedNodeDeleteTotalMetric       = "failed_node_delete_total"
 	RejectedEventsTotalMetric         = "rejected_events_total"
 )
 
@@ -53,9 +55,11 @@ func (m *MetricsServer) Start() {
 		SuccessfulEventsTotalMetric:       "indicates the sum of all successful events.",
 		SuccessfulLBDeregisterTotalMetric: "indicates the sum of all events that succeeded to deregister loadbalancer",
 		SuccessfulNodeDrainTotalMetric:    "indicates the sum of all events that succeeded to drain the node.",
+		SuccessfulNodeDeleteTotalMetric:   "indicates the sum of all events that succeeded to delete the node.",
 		FailedEventsTotalMetric:           "indicates the sum of all failed events.",
 		FailedLBDeregisterTotalMetric:     "indicates the sum of all events that failed to deregister loadbalancer.",
 		FailedNodeDrainTotalMetric:        "indicates the sum of all events that failed to drain the node.",
+		FailedNodeDeleteTotalMetric:       "indicates the sum of all events that failed to delete the node.",
 		RejectedEventsTotalMetric:         "indicates the sum of all rejected events.",
 	}
 

--- a/pkg/service/nodes.go
+++ b/pkg/service/nodes.go
@@ -92,6 +92,17 @@ func drainNode(kubeClient kubernetes.Interface, node *v1.Node, timeout, retryInt
 	return err
 }
 
+func deleteNode(kubeClient kubernetes.Interface, node *v1.Node) error {
+	err := deleteNodeUtil(node, kubeClient)
+	if err != nil {
+		log.Errorf("failed to delete node %v  error: %v ", node.Name, err)
+		return err
+	}
+
+	log.Info("node successfully deleted")
+	return nil
+}
+
 func runCommand(call string, arg []string) (string, error) {
 	log.Debugf("invoking >> %s %s", call, arg)
 	out, err := exec.Command(call, arg...).CombinedOutput()
@@ -191,4 +202,8 @@ func drainNodeUtil(node *v1.Node, DrainTimeout int, client kubernetes.Interface)
 		return fmt.Errorf("error draining node: %v", err)
 	}
 	return err
+}
+
+func deleteNodeUtil(node *v1.Node, client kubernetes.Interface) error {
+	return nil
 }

--- a/pkg/service/nodes.go
+++ b/pkg/service/nodes.go
@@ -205,5 +205,17 @@ func drainNodeUtil(node *v1.Node, DrainTimeout int, client kubernetes.Interface)
 }
 
 func deleteNodeUtil(node *v1.Node, client kubernetes.Interface) error {
+
+	var err error = nil
+
+	if _, ok := getNodeByName(client, node.Name); !ok {
+		return fmt.Errorf("node not found")
+	}
+
+	err = client.CoreV1().Nodes().Delete(context.Background(), node.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete node %q: %v", node.Name, err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
node IPs are reused by the cloud providers. When a new node joins the cluster with a previously allocated IP, it will fetch the same object which has a previous role and labels. Because of this the node is never able to join the cluster and will be stuck in `NotReady` state. Therefore, once the node is drained, we can safely delete the node.