### PR TITLE
Permormance optimiztion: avoid some list call, increase client-go QPS

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -41,6 +41,8 @@ func newKubernetesClient(localMode string) *kubernetes.Clientset {
 		if err != nil {
 			log.Fatalln("cannot load kubernetes config from InCluster")
 		}
+		config.QPS = 600
+		config.Burst = 2000
 	}
 	return kubernetes.NewForConfigOrDie(config)
 }

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -27,8 +27,10 @@ type Manager struct {
 	context          ManagerContext
 	deregistrationMu sync.Mutex
 	sync.Mutex
-	workQueue       []*LifecycleEvent
-	targets         *sync.Map
+	workQueue []*LifecycleEvent
+	targets   *sync.Map
+	// nodeMetadataMap stores the node instanceID -> name mapping
+	nodeMetadataMap map[string]string
 	metrics         *MetricsServer
 	avarageLatency  float64
 	completedEvents int
@@ -87,12 +89,13 @@ type WaiterError struct {
 
 func New(auth Authenticator, ctx ManagerContext) *Manager {
 	return &Manager{
-		eventStream:   make(chan *sqs.Message, 0),
-		workQueue:     make([]*LifecycleEvent, 0),
-		metrics:       &MetricsServer{},
-		targets:       &sync.Map{},
-		authenticator: auth,
-		context:       ctx,
+		eventStream:     make(chan *sqs.Message, 100),
+		workQueue:       make([]*LifecycleEvent, 0),
+		nodeMetadataMap: make(map[string]string),
+		metrics:         &MetricsServer{},
+		targets:         &sync.Map{},
+		authenticator:   auth,
+		context:         ctx,
 	}
 }
 

--- a/pkg/service/nodes.go
+++ b/pkg/service/nodes.go
@@ -38,21 +38,13 @@ func getNodeByInstance(k kubernetes.Interface, instanceID string) (v1.Node, bool
 	return foundNode, false
 }
 
-func getNodeByName(k kubernetes.Interface, nodeName string) (v1.Node, bool) {
-	var foundNode v1.Node
-	nodes, err := k.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+func getNodeByName(k kubernetes.Interface, nodeName string) (*v1.Node, bool) {
+	foundNode, err := k.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
 	if err != nil {
-		log.Errorf("failed to list nodes: %v", err)
+		log.Errorf("failed to get node %v: %v", nodeName, err)
 		return foundNode, false
 	}
-
-	for _, node := range nodes.Items {
-		if node.Name == nodeName {
-			return node, true
-		}
-	}
-
-	return foundNode, false
+	return foundNode, true
 }
 
 func isNodeStatusInCondition(node v1.Node, condition v1.ConditionStatus) bool {

--- a/pkg/service/nodes.go
+++ b/pkg/service/nodes.go
@@ -17,25 +17,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func getNodeByInstance(k kubernetes.Interface, instanceID string) (v1.Node, bool) {
-	var foundNode v1.Node
-	nodes, err := k.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		log.Errorf("failed to list nodes: %v", err)
-		return foundNode, false
-	}
-
-	for _, node := range nodes.Items {
-		providerID := node.Spec.ProviderID
-		splitProviderID := strings.Split(providerID, "/")
-		foundID := splitProviderID[len(splitProviderID)-1]
-
-		if instanceID == foundID {
-			return node, true
-		}
-	}
-
-	return foundNode, false
+func getNodeInstanceID(node v1.Node) string {
+	providerID := node.Spec.ProviderID
+	splitProviderID := strings.Split(providerID, "/")
+	return splitProviderID[len(splitProviderID)-1]
 }
 
 func getNodeByName(k kubernetes.Interface, nodeName string) (*v1.Node, bool) {

--- a/pkg/service/nodes_test.go
+++ b/pkg/service/nodes_test.go
@@ -51,56 +51,16 @@ func Test_NodeStatusPredicate(t *testing.T) {
 
 }
 
-func Test_GetNodeByInstancePositive(t *testing.T) {
-	t.Log("Test_GetNodeByInstancePositive: If a node exists, should be able to get it's instance ID")
-	kubeClient := fake.NewSimpleClientset()
-	fakeNodes := []v1.Node{
-		{
-			Spec: v1.NodeSpec{
-				ProviderID: "aws:///us-west-2a/i-11111111111111111",
-			},
-		},
-		{
-			Spec: v1.NodeSpec{
-				ProviderID: "aws:///us-west-2c/i-22222222222222222",
-			},
+func Test_GetNodeInstanceID(t *testing.T) {
+	t.Log("Test_GetNodeInstanceID: If a node exists, should be able to get it's instance ID")
+	fakeNode := v1.Node{
+		Spec: v1.NodeSpec{
+			ProviderID: "aws:///us-west-2a/i-11111111111111111",
 		},
 	}
+	expected := "i-11111111111111111"
 
-	for _, node := range fakeNodes {
-		kubeClient.CoreV1().Nodes().Create(context.Background(), &node, apimachinery_v1.CreateOptions{})
-	}
-
-	_, exists := getNodeByInstance(kubeClient, "i-11111111111111111")
-	expected := true
-
-	if exists != expected {
-		t.Fatalf("expected getNodeByInstance exists to be: %v, got: %v", expected, exists)
-	}
-}
-
-func Test_GetNodeByInstanceNegative(t *testing.T) {
-	t.Log("Test_GetNodeByInstanceNegative: If a node exists, should be able to get it's instance ID")
-	kubeClient := fake.NewSimpleClientset()
-	fakeNodes := []v1.Node{
-		{
-			Spec: v1.NodeSpec{
-				ProviderID: "aws:///us-west-2a/i-11111111111111111",
-			},
-		},
-		{
-			Spec: v1.NodeSpec{
-				ProviderID: "aws:///us-west-2c/i-22222222222222222",
-			},
-		},
-	}
-
-	for _, node := range fakeNodes {
-		kubeClient.CoreV1().Nodes().Create(context.Background(), &node, apimachinery_v1.CreateOptions{})
-	}
-
-	_, exists := getNodeByInstance(kubeClient, "i-3333333333333333")
-	expected := false
+	exists := getNodeInstanceID(fakeNode)
 
 	if exists != expected {
 		t.Fatalf("expected getNodeByInstance exists to be: %v, got: %v", expected, exists)

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -134,10 +134,6 @@ func (mgr *Manager) newEvent(message *sqs.Message, queueURL string) (*LifecycleE
 	if err = mgr.validateEvent(event); err != nil {
 		return event, err
 	}
-<<<<<<< HEAD
-
-=======
->>>>>>> 1abacb1 (add node metadata cache)
 	return event, nil
 }
 
@@ -163,14 +159,6 @@ func (mgr *Manager) validateEvent(e *LifecycleEvent) error {
 		return errors.New("event already exists in queue")
 	}
 
-<<<<<<< HEAD
-	node, exists := getNodeByInstance(kubeClient, e.EC2InstanceID)
-	if !exists {
-		return errors.Errorf("instance %v is not seen in cluster nodes", e.EC2InstanceID)
-	}
-
-	heartbeatInterval, err := getHookHeartbeatInterval(auth.ScalingGroupClient, e.LifecycleHookName, e.AutoScalingGroupName)
-=======
 	var node *v1.Node
 	var err error
 	nodeName, ok := mgr.nodeMetadataMap[e.EC2InstanceID]
@@ -203,7 +191,6 @@ func (mgr *Manager) validateEvent(e *LifecycleEvent) error {
 
 	heartbeatInterval, err := getHookHeartbeatInterval(auth.ScalingGroupClient, e.LifecycleHookName, e.AutoScalingGroupName)
 
->>>>>>> 1abacb1 (add node metadata cache)
 	if err != nil {
 		return errors.Wrap(err, "failed to get hook heartbeat interval")
 	}


### PR DESCRIPTION
## Issue
When we terminate a large mount of nodes at the same time, let's 600 nodes, lifecycle-manager can only process 75 node events per minute, which means `600/75=8` min. If we set the ASG Lifecycle hook's heartbeat timeout seconds to 300s, then some of the node events will never get processed and after the 300s timeout, the node will get terminated by ASG directly without proper drain, which leads to pod ungraceful shutdown.

## Fixes/Improvements
1. Increase client-go `QPS` from 5 to 600, `Burst` from 10 to 2000
2. Add `nodeMetadataMap` to cache the node instanceID --> node name info (reduce the k8s client list call).
3. `getNodeByName()` is used during node drain/delete. it should use the Get() API instead of List()

After the improvements, lifecycle-manager could handle 200 node messages per minute.