### PR TITLE
increase qps and burst to 100

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -41,6 +41,8 @@ func newKubernetesClient(localMode string) *kubernetes.Clientset {
 		if err != nil {
 			log.Fatalln("cannot load kubernetes config from InCluster")
 		}
+		config.QPS = 100
+		config.Burst = 100
 	}
 	return kubernetes.NewForConfigOrDie(config)
 }


### PR DESCRIPTION
## Issue
When we terminate a large mount of nodes at the same time, let's say 600 nodes, lifecycle-manager can only process 75 node events per minute, which means `600/75=8` min. If we set the ASG Lifecycle hook's heartbeat timeout seconds to 300s, then some of the node events will never get processed and after the 300s timeout, the node will get terminated by ASG directly without proper drain, which leads to pod ungraceful shutdown.

## Fixes/Improvements
1. Increase client-go `QPS` from 5 to 100, `Burst` from 10 to 100

Now we are able to process 110 nodes per minute