### PR TITLE
Reimplement retry-interval when draining nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/keikoproj/lifecycle-manager
 go 1.19
 
 require (
+	github.com/avast/retry-go/v4 v4.5.1
 	github.com/aws/aws-sdk-go v1.48.11
 	github.com/keikoproj/aws-sdk-go-cache v0.0.2
 	github.com/keikoproj/inverse-exp-backoff v0.0.4
@@ -22,6 +23,7 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,10 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
+github.com/avast/retry-go/v4 v4.5.1 h1:AxIx0HGi4VZ3I02jr78j5lZ3M6x1E0Ivxa6b0pUUh7o=
+github.com/avast/retry-go/v4 v4.5.1/go.mod h1:/sipNsvNB3RRuT5iNcb6h73nw3IBmXJ/H3XrCQYSOpc=
 github.com/aws/aws-sdk-go v1.48.11 h1:9YbiSbaF/jWi+qLRl+J5dEhr2mcbDYHmKg2V7RBcD5M=
 github.com/aws/aws-sdk-go v1.48.11/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/service/nodes.go
+++ b/pkg/service/nodes.go
@@ -9,12 +9,13 @@ import (
 	"time"
 
 	retry "github.com/avast/retry-go"
-	"github.com/keikoproj/lifecycle-manager/pkg/log"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	drain "k8s.io/kubectl/pkg/drain"
+
+	"github.com/keikoproj/lifecycle-manager/pkg/log"
+	"k8s.io/client-go/kubernetes"
 )
 
 func getNodeByInstance(k kubernetes.Interface, instanceID string) (v1.Node, bool) {

--- a/pkg/service/nodes_test.go
+++ b/pkg/service/nodes_test.go
@@ -192,7 +192,7 @@ func Test_DrainNodeNegative(t *testing.T) {
 		},
 	}
 
-	err := drainNode(kubeClient, unjoinedNode, 10, 30, 3)
+	err := drainNode(kubeClient, unjoinedNode, 10, 0, 3)
 	if err == nil {
 		t.Fatalf("drainNode: expected error to have occured, %v", err)
 	}


### PR DESCRIPTION
This addresses https://github.com/keikoproj/lifecycle-manager/issues/185 by re-adding the `retryInterval` when draining.

This also re-adds the `retry-go` package in order to do both the retry and the delay functionality. If there was another reason for removing it let me know!

Testing this on an actual cluster with setting the drain-interval to 30 seconds and the drain-timeout to 120 seconds I can see  from the logs that there is the correct amount of time between retries.

```
time="2024-01-12T19:32:06Z" level=info msg="retrying drain, node <node name>"
time="2024-01-12T19:34:36Z" level=info msg="retrying drain, node <node name>"
# 2 minutes 30 seconds between retries
```