### PR TITLE
fix: graceful pod termination when max-time-to-process is exceeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ time="2020-03-11T07:24:49Z" level=info msg="event ce25c321-ec67-3f0b-c156-a7c1f7
 | log-level | "info" | String | the logging level (info, warning, debug) |
 | max-drain-concurrency | 32 | Int | maximum number of node drains to process in parallel |
 | max-time-to-process | 3600 | Int | max time to spend processing an event |
+| max-termination-grace-period | 900 | Int | grace period in seconds to wait for pods to terminate after max-time-to-process is reached |
 | drain-timeout | 300 | Int | hard time limit for draining healthy nodes |
 | drain-timeout-unknown | 30 | Int | hard time limit for draining nodes that are in unknown state |
 | drain-interval | 30 | Int | interval in seconds for which to retry draining |

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -39,7 +39,8 @@ var (
 	drainTimeoutUnknownSeconds int
 	drainRetryAttempts         int
 	pollingIntervalSeconds     int
-	maxTimeToProcessSeconds    int64
+	maxTimeToProcessSeconds       int64
+	maxTerminationGracePeriod     int64
 
 	// DefaultRetryer is the default retry configuration for some AWS API calls
 	DefaultRetryer = client.DefaultRetryer{
@@ -82,6 +83,7 @@ var serveCmd = &cobra.Command{
 			DrainRetryIntervalSeconds:  int64(drainRetryIntervalSeconds),
 			MaxDrainConcurrency:        semaphore.NewWeighted(maxDrainConcurrency),
 			MaxTimeToProcessSeconds:    int64(maxTimeToProcessSeconds),
+			MaxTerminationGracePeriod:  maxTerminationGracePeriod,
 			DrainRetryAttempts:         uint(drainRetryAttempts),
 			Region:                     region,
 			WithDeregister:             deregisterTargetGroups,
@@ -110,6 +112,7 @@ func init() {
 	serveCmd.Flags().BoolVar(&deregisterTargetGroups, "with-deregister", true, "try to deregister deleting instance from target groups")
 	serveCmd.Flags().StringSliceVar(&deregisterTargetTypes, "deregister-target-types", []string{service.TargetTypeClassicELB.String(), service.TargetTypeTargetGroup.String()},
 		fmt.Sprintf("comma separated list of target types to deregister instance from (%s, %s)", service.TargetTypeClassicELB.String(), service.TargetTypeTargetGroup.String()))
+	serveCmd.Flags().Int64Var(&maxTerminationGracePeriod, "max-termination-grace-period", 900, "grace period in seconds to wait for pods to terminate after max-time-to-process is reached")
 	serveCmd.Flags().BoolVar(&refreshExpiredCredentials, "refresh-expired-credentials", false, "refreshes expired credentials (requires shared credentials file)")
 }
 

--- a/pkg/service/autoscaling.go
+++ b/pkg/service/autoscaling.go
@@ -7,11 +7,23 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
+	iebackoff "github.com/keikoproj/inverse-exp-backoff"
 	"github.com/keikoproj/lifecycle-manager/pkg/log"
+	"k8s.io/client-go/kubernetes"
 )
 
-func sendHeartbeat(client autoscalingiface.AutoScalingAPI, event *LifecycleEvent, maxTimeToProcessSeconds int64) {
+type heartbeatConfig struct {
+	asgClient                 autoscalingiface.AutoScalingAPI
+	kubeClient                kubernetes.Interface
+	event                     *LifecycleEvent
+	maxTimeToProcessSeconds   int64
+	maxTerminationGracePeriod int64
+}
+
+func sendHeartbeat(cfg heartbeatConfig) {
 	var (
+		event               = cfg.event
+		client              = cfg.asgClient
 		iterationCount      = 0
 		interval            = event.heartbeatInterval
 		instanceID          = event.EC2InstanceID
@@ -21,15 +33,17 @@ func sendHeartbeat(client autoscalingiface.AutoScalingAPI, event *LifecycleEvent
 
 	log.Debugf("scaling-group = %v, maxInterval = %v, heartbeat = %v", scalingGroupName, interval, recommendedInterval)
 
-	// max time to process an event is capped at 1hr
-	maxIterations := int(maxTimeToProcessSeconds / recommendedInterval)
+	maxIterations := int(cfg.maxTimeToProcessSeconds / recommendedInterval)
+
+	startTime := time.Now()
 
 	for {
 		iterationCount++
 		if iterationCount >= maxIterations {
-			// hard limit in case event is not marked completed
-			log.Warnf("%v> heartbeat extended over threshold, instance will be abandoned", instanceID)
-			event.SetEventCompleted(true)
+			elapsed := time.Since(startTime).Round(time.Second)
+			log.Warnf("%v> heartbeat extended over threshold after %v, beginning graceful pod termination", instanceID, elapsed)
+			handleHeartbeatTimeout(cfg)
+			return
 		}
 
 		if event.eventCompleted {
@@ -44,6 +58,86 @@ func sendHeartbeat(client autoscalingiface.AutoScalingAPI, event *LifecycleEvent
 		}
 		time.Sleep(time.Duration(recommendedInterval) * time.Second)
 	}
+}
+
+func handleHeartbeatTimeout(cfg heartbeatConfig) {
+	var (
+		event      = cfg.event
+		client     = cfg.asgClient
+		kubeClient = cfg.kubeClient
+		instanceID = event.EC2InstanceID
+		nodeName   = event.referencedNode.Name
+	)
+
+	deleted, err := deletePodsOnNode(kubeClient, nodeName, cfg.maxTerminationGracePeriod)
+	if err != nil {
+		log.Errorf("%v> failed to delete pods on node %s: %v", instanceID, nodeName, err)
+	} else {
+		log.Infof("%v> requested deletion of %d non-daemonset pods on node %s", instanceID, deleted, nodeName)
+	}
+
+	msg := fmt.Sprintf(EventMessageHeartbeatTimeoutGracefulTermination, instanceID, deleted, nodeName)
+	kEvent := newKubernetesEvent(EventReasonHeartbeatTimeoutGracefulTermination, getMessageFields(event, msg))
+	publishKubernetesEvent(kubeClient, kEvent)
+
+	waitForPodsWithHeartbeat(cfg)
+
+	if event.eventCompleted {
+		log.Infof("%v> event already completed by main goroutine, skipping ABANDON", instanceID)
+	} else {
+		log.Warnf("%v> completing lifecycle action with ABANDON after timeout", instanceID)
+		if err := completeLifecycleAction(client, *event, AbandonAction); err != nil {
+			log.Errorf("%v> failed to complete lifecycle action with ABANDON: %v", instanceID, err)
+		}
+	}
+
+	event.SetEventCompleted(true)
+}
+
+func waitForPodsWithHeartbeat(cfg heartbeatConfig) {
+	var (
+		event      = cfg.event
+		client     = cfg.asgClient
+		kubeClient = cfg.kubeClient
+		instanceID = event.EC2InstanceID
+		nodeName   = event.referencedNode.Name
+		timeout    = time.Duration(cfg.maxTerminationGracePeriod) * time.Second
+		maxDelay   = WaiterMaxDelay
+		minDelay   = WaiterMinDelay
+	)
+
+	if timeout <= 0 {
+		return
+	}
+	if maxDelay > timeout {
+		maxDelay = timeout / 2
+	}
+	if minDelay > maxDelay {
+		minDelay = maxDelay
+	}
+
+	ieb, err := iebackoff.NewIEBWithTimeout(maxDelay, minDelay, timeout, 0.5, time.Now())
+	if err != nil {
+		log.Errorf("%v> failed to create inverse-exp-backoff: %v", instanceID, err)
+		return
+	}
+
+	for ; err == nil; err = ieb.Next() {
+		if err := extendLifecycleAction(client, *event); err != nil {
+			log.Errorf("%v> failed to send heartbeat during termination grace period: %v", instanceID, err)
+		}
+
+		active := countActivePods(kubeClient, nodeName)
+		if active == 0 {
+			log.Infof("%v> all non-daemonset pods terminated on node %s", instanceID, nodeName)
+			return
+		}
+		if active > 0 {
+			log.Infof("%v> waiting for %d non-daemonset pods to terminate on node %s", instanceID, active, nodeName)
+		}
+	}
+
+	log.Warnf("%v> termination grace period expired with pods still running on node %s", instanceID, nodeName)
 }
 
 func getHookHeartbeatInterval(client autoscalingiface.AutoScalingAPI, lifecycleHookName, scalingGroupName string) (int64, error) {

--- a/pkg/service/autoscaling_test.go
+++ b/pkg/service/autoscaling_test.go
@@ -1,12 +1,16 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 type stubAutoscaling struct {
@@ -15,6 +19,7 @@ type stubAutoscaling struct {
 	timesCalledDescribeLifecycleHooks         int
 	timesCalledRecordLifecycleActionHeartbeat int
 	timesCalledCompleteLifecycleAction        int
+	lastCompleteAction                        string
 }
 
 func (a *stubAutoscaling) DescribeLifecycleHooks(input *autoscaling.DescribeLifecycleHooksInput) (*autoscaling.DescribeLifecycleHooksOutput, error) {
@@ -29,6 +34,9 @@ func (a *stubAutoscaling) RecordLifecycleActionHeartbeat(input *autoscaling.Reco
 
 func (a *stubAutoscaling) CompleteLifecycleAction(input *autoscaling.CompleteLifecycleActionInput) (*autoscaling.CompleteLifecycleActionOutput, error) {
 	a.timesCalledCompleteLifecycleAction++
+	if input.LifecycleActionResult != nil {
+		a.lastCompleteAction = *input.LifecycleActionResult
+	}
 	return &autoscaling.CompleteLifecycleActionOutput{}, nil
 }
 
@@ -40,6 +48,7 @@ func (e *LifecycleEvent) _setEventCompletedAfter(value bool, seconds int64) {
 func Test_SendHeartbeatPositive(t *testing.T) {
 	t.Log("Test_SendHeartbeatPositive: If drain is not complete, a heartbeat should be sent")
 	stubber := &stubAutoscaling{}
+	kubeClient := fake.NewSimpleClientset()
 	event := &LifecycleEvent{
 		AutoScalingGroupName: "my-asg",
 		EC2InstanceID:        "i-1234567890",
@@ -48,10 +57,15 @@ func Test_SendHeartbeatPositive(t *testing.T) {
 		drainCompleted:       false,
 		heartbeatInterval:    3,
 	}
-	maxTimeToProcessSeconds := int64(3600)
 
 	go event._setEventCompletedAfter(true, 2)
-	sendHeartbeat(stubber, event, maxTimeToProcessSeconds)
+	sendHeartbeat(heartbeatConfig{
+		asgClient:                 stubber,
+		kubeClient:                kubeClient,
+		event:                     event,
+		maxTimeToProcessSeconds:   3600,
+		maxTerminationGracePeriod: 900,
+	})
 	expectedHeartbeatCalls := 3
 
 	if stubber.timesCalledRecordLifecycleActionHeartbeat != expectedHeartbeatCalls {
@@ -62,6 +76,7 @@ func Test_SendHeartbeatPositive(t *testing.T) {
 func Test_SendHeartbeatNegative(t *testing.T) {
 	t.Log("Test_SendHeartbeatNegative: If event is completed, heartbeat should not be sent")
 	stubber := &stubAutoscaling{}
+	kubeClient := fake.NewSimpleClientset()
 	event := &LifecycleEvent{
 		AutoScalingGroupName: "my-asg",
 		EC2InstanceID:        "i-1234567890",
@@ -70,13 +85,133 @@ func Test_SendHeartbeatNegative(t *testing.T) {
 		eventCompleted:       true,
 		heartbeatInterval:    3,
 	}
-	maxTimeToProcessSeconds := int64(3600)
 
-	sendHeartbeat(stubber, event, maxTimeToProcessSeconds)
+	sendHeartbeat(heartbeatConfig{
+		asgClient:                 stubber,
+		kubeClient:                kubeClient,
+		event:                     event,
+		maxTimeToProcessSeconds:   3600,
+		maxTerminationGracePeriod: 900,
+	})
 	expectedHeartbeatCalls := 0
 
 	if stubber.timesCalledRecordLifecycleActionHeartbeat != expectedHeartbeatCalls {
 		t.Fatalf("expected timesCalledRecordLifecycleActionHeartbeat: %v, got: %v", expectedHeartbeatCalls, stubber.timesCalledRecordLifecycleActionHeartbeat)
+	}
+}
+
+func Test_SendHeartbeatTimeoutDeletesPods(t *testing.T) {
+	t.Log("Test_SendHeartbeatTimeoutDeletesPods: When max-time-to-process is reached, pods should be deleted and ABANDON called")
+	stubber := &stubAutoscaling{}
+	kubeClient := fake.NewSimpleClientset()
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+		Spec:       v1.NodeSpec{ProviderID: "aws:///us-west-2a/i-1234567890"},
+	}
+	kubeClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+		Spec: v1.PodSpec{NodeName: "test-node"},
+	}
+	kubeClient.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{})
+
+	event := &LifecycleEvent{
+		AutoScalingGroupName: "my-asg",
+		EC2InstanceID:        "i-1234567890",
+		LifecycleActionToken: "some-token-1234",
+		LifecycleHookName:    "my-hook",
+		heartbeatInterval:    2,
+		referencedNode:       *node,
+	}
+
+	sendHeartbeat(heartbeatConfig{
+		asgClient:                 stubber,
+		kubeClient:                kubeClient,
+		event:                     event,
+		maxTimeToProcessSeconds:   1,
+		maxTerminationGracePeriod: 1,
+	})
+
+	if !event.eventCompleted {
+		t.Fatal("expected eventCompleted to be true after timeout")
+	}
+
+	if stubber.timesCalledCompleteLifecycleAction != 1 {
+		t.Fatalf("expected CompleteLifecycleAction called once, got: %v", stubber.timesCalledCompleteLifecycleAction)
+	}
+
+	if stubber.lastCompleteAction != AbandonAction {
+		t.Fatalf("expected ABANDON action, got: %v", stubber.lastCompleteAction)
+	}
+
+	pods, _ := kubeClient.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
+	if len(pods.Items) != 0 {
+		t.Fatalf("expected pod to be deleted, but %d pods remain", len(pods.Items))
+	}
+}
+
+func Test_SendHeartbeatTimeoutSkipsDaemonSetPods(t *testing.T) {
+	t.Log("Test_SendHeartbeatTimeoutSkipsDaemonSetPods: DaemonSet pods should not be deleted on timeout")
+	stubber := &stubAutoscaling{}
+	kubeClient := fake.NewSimpleClientset()
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+		Spec:       v1.NodeSpec{ProviderID: "aws:///us-west-2a/i-1234567890"},
+	}
+	kubeClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+
+	dsPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ds-pod",
+			Namespace: "kube-system",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "DaemonSet", Name: "my-ds", APIVersion: "apps/v1"},
+			},
+		},
+		Spec: v1.PodSpec{NodeName: "test-node"},
+	}
+	kubeClient.CoreV1().Pods("kube-system").Create(context.Background(), dsPod, metav1.CreateOptions{})
+
+	regularPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "regular-pod",
+			Namespace: "default",
+		},
+		Spec: v1.PodSpec{NodeName: "test-node"},
+	}
+	kubeClient.CoreV1().Pods("default").Create(context.Background(), regularPod, metav1.CreateOptions{})
+
+	event := &LifecycleEvent{
+		AutoScalingGroupName: "my-asg",
+		EC2InstanceID:        "i-1234567890",
+		LifecycleActionToken: "some-token-1234",
+		LifecycleHookName:    "my-hook",
+		heartbeatInterval:    2,
+		referencedNode:       *node,
+	}
+
+	sendHeartbeat(heartbeatConfig{
+		asgClient:                 stubber,
+		kubeClient:                kubeClient,
+		event:                     event,
+		maxTimeToProcessSeconds:   1,
+		maxTerminationGracePeriod: 1,
+	})
+
+	dsPods, _ := kubeClient.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{})
+	if len(dsPods.Items) != 1 {
+		t.Fatalf("expected daemonset pod to survive, but got %d pods", len(dsPods.Items))
+	}
+
+	regularPods, _ := kubeClient.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
+	if len(regularPods.Items) != 0 {
+		t.Fatalf("expected regular pod to be deleted, but got %d pods", len(regularPods.Items))
 	}
 }
 

--- a/pkg/service/events.go
+++ b/pkg/service/events.go
@@ -69,6 +69,10 @@ const (
 	EventReasonInstanceDeregisterFailed EventReason = "InstanceDeregisterFailed"
 	// EventMessageInstanceDeregisterFailed is the message for a successful classic elb deregister event
 	EventMessageInstanceDeregisterFailed = "instance %v has failed to deregister from classic-elb %v: %v"
+	// EventReasonHeartbeatTimeoutGracefulTermination is the reason for a heartbeat-timeout triggered pod cleanup
+	EventReasonHeartbeatTimeoutGracefulTermination EventReason = "HeartbeatTimeoutGracefulTermination"
+	// EventMessageHeartbeatTimeoutGracefulTermination is the message for a heartbeat-timeout triggered pod cleanup
+	EventMessageHeartbeatTimeoutGracefulTermination = "instance %v exceeded max-time-to-process, deleted %v pods for graceful termination on node %v"
 )
 
 var (
@@ -86,8 +90,9 @@ var (
 		EventReasonNodeDrainFailed:             EventLevelWarning,
 		EventReasonTargetDeregisterSucceeded:   EventLevelNormal,
 		EventReasonTargetDeregisterFailed:      EventLevelWarning,
-		EventReasonInstanceDeregisterSucceeded: EventLevelNormal,
-		EventReasonInstanceDeregisterFailed:    EventLevelWarning,
+		EventReasonInstanceDeregisterSucceeded:         EventLevelNormal,
+		EventReasonInstanceDeregisterFailed:            EventLevelWarning,
+		EventReasonHeartbeatTimeoutGracefulTermination: EventLevelWarning,
 	}
 )
 

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -51,6 +51,7 @@ type ManagerContext struct {
 	DeregisterTargetTypes      []string
 	MaxDrainConcurrency        *semaphore.Weighted
 	MaxTimeToProcessSeconds    int64
+	MaxTerminationGracePeriod  int64
 }
 
 // Authenticator holds clients for all required APIs

--- a/pkg/service/nodes.go
+++ b/pkg/service/nodes.go
@@ -207,6 +207,109 @@ func drainNodeUtil(node *v1.Node, DrainTimeout int, client kubernetes.Interface)
 	return err
 }
 
+func isDaemonSetPod(pod *v1.Pod) bool {
+	for _, ref := range pod.OwnerReferences {
+		if ref.Kind == "DaemonSet" {
+			return true
+		}
+	}
+	return false
+}
+
+const podListMaxRetries = 3
+
+// listActivePodsOnNode returns non-daemonset, non-terminal pods scheduled on
+// the given node. The List call is retried up to podListMaxRetries times with
+// linear backoff to ride out transient API-server errors.
+func listActivePodsOnNode(
+	kubeClient kubernetes.Interface,
+	nodeName string,
+) ([]v1.Pod, error) {
+	listOpts := metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+	}
+
+	var podList *v1.PodList
+	var err error
+	for attempt := 1; attempt <= podListMaxRetries; attempt++ {
+		podList, err = kubeClient.CoreV1().Pods("").List(context.Background(), listOpts)
+		if err == nil {
+			break
+		}
+		log.Errorf("failed to list pods on node %s (attempt %d/%d): %v", nodeName, attempt, podListMaxRetries, err)
+		if attempt < podListMaxRetries {
+			time.Sleep(time.Duration(attempt) * time.Second)
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods on node %s after %d attempts: %v", nodeName, podListMaxRetries, err)
+	}
+
+	active := make([]v1.Pod, 0, len(podList.Items))
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if isDaemonSetPod(pod) {
+			continue
+		}
+		if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+			continue
+		}
+		active = append(active, *pod)
+	}
+	return active, nil
+}
+
+func deletePodsOnNode(
+	kubeClient kubernetes.Interface,
+	nodeName string,
+	gracePeriodSeconds int64,
+) (int, error) {
+	pods, err := listActivePodsOnNode(kubeClient, nodeName)
+	if err != nil {
+		return 0, err
+	}
+
+	deleted := 0
+	for i := range pods {
+		pod := &pods[i]
+		podGrace := gracePeriodSeconds
+		if pod.Spec.TerminationGracePeriodSeconds != nil && *pod.Spec.TerminationGracePeriodSeconds < podGrace {
+			podGrace = *pod.Spec.TerminationGracePeriodSeconds
+		}
+
+		log.Infof("deleting pod %s/%s on node %s (grace period: %ds)", pod.Namespace, pod.Name, nodeName, podGrace)
+		if deletePodWithRetry(kubeClient, pod.Namespace, pod.Name, podGrace, podListMaxRetries) {
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+func deletePodWithRetry(kubeClient kubernetes.Interface, namespace, name string, gracePeriodSeconds int64, maxRetries int) bool {
+	deleteOpts := metav1.DeleteOptions{
+		GracePeriodSeconds: &gracePeriodSeconds,
+	}
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		err := kubeClient.CoreV1().Pods(namespace).Delete(context.Background(), name, deleteOpts)
+		if err == nil {
+			return true
+		}
+		log.Errorf("failed to delete pod %s/%s (attempt %d/%d): %v", namespace, name, attempt, maxRetries, err)
+		if attempt < maxRetries {
+			time.Sleep(time.Duration(attempt) * time.Second)
+		}
+	}
+	return false
+}
+
+func countActivePods(kubeClient kubernetes.Interface, nodeName string) int {
+	pods, err := listActivePodsOnNode(kubeClient, nodeName)
+	if err != nil {
+		return -1
+	}
+	return len(pods)
+}
+
 func deleteNodeUtil(node *v1.Node, client kubernetes.Interface) error {
 
 	var err error = nil

--- a/pkg/service/nodes_test.go
+++ b/pkg/service/nodes_test.go
@@ -228,3 +228,147 @@ func Test_LabelNodeNegative(t *testing.T) {
 		t.Fatalf("Test_LabelNode: expected error to have occured, %v", err)
 	}
 }
+
+func Test_IsDaemonSetPod(t *testing.T) {
+	t.Log("Test_IsDaemonSetPod: should correctly identify daemonset pods")
+
+	dsPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "DaemonSet", Name: "my-ds", APIVersion: "apps/v1"},
+			},
+		},
+	}
+	if !isDaemonSetPod(dsPod) {
+		t.Fatal("expected daemonset pod to be identified as such")
+	}
+
+	regularPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: "my-rs", APIVersion: "apps/v1"},
+			},
+		},
+	}
+	if isDaemonSetPod(regularPod) {
+		t.Fatal("expected regular pod not to be identified as daemonset pod")
+	}
+
+	noPod := &v1.Pod{}
+	if isDaemonSetPod(noPod) {
+		t.Fatal("expected pod with no owner references not to be identified as daemonset pod")
+	}
+}
+
+func Test_DeletePodsOnNode(t *testing.T) {
+	t.Log("Test_DeletePodsOnNode: should delete non-daemonset pods and skip daemonset pods")
+	kubeClient := fake.NewSimpleClientset()
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+	}
+	kubeClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+
+	regularPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "regular-pod", Namespace: "default"},
+		Spec:       v1.PodSpec{NodeName: "test-node"},
+		Status:     v1.PodStatus{Phase: v1.PodRunning},
+	}
+	kubeClient.CoreV1().Pods("default").Create(context.Background(), regularPod, metav1.CreateOptions{})
+
+	dsPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ds-pod",
+			Namespace: "kube-system",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "DaemonSet", Name: "my-ds", APIVersion: "apps/v1"},
+			},
+		},
+		Spec:   v1.PodSpec{NodeName: "test-node"},
+		Status: v1.PodStatus{Phase: v1.PodRunning},
+	}
+	kubeClient.CoreV1().Pods("kube-system").Create(context.Background(), dsPod, metav1.CreateOptions{})
+
+	deleted, err := deletePodsOnNode(kubeClient, "test-node", 900)
+	if err != nil {
+		t.Fatalf("deletePodsOnNode: expected no error, got: %v", err)
+	}
+
+	if deleted != 1 {
+		t.Fatalf("expected 1 pod deleted, got: %d", deleted)
+	}
+
+	remaining, _ := kubeClient.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{})
+	if len(remaining.Items) != 1 {
+		t.Fatalf("expected daemonset pod to remain, got %d pods", len(remaining.Items))
+	}
+}
+
+func Test_DeletePodsOnNodeCapsGracePeriod(t *testing.T) {
+	t.Log("Test_DeletePodsOnNodeCapsGracePeriod: pod grace period should be capped to maxTerminationGracePeriod")
+	kubeClient := fake.NewSimpleClientset()
+
+	longGrace := int64(600)
+	shortGrace := int64(30)
+
+	longGracePod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "long-grace-pod", Namespace: "default"},
+		Spec:       v1.PodSpec{NodeName: "test-node", TerminationGracePeriodSeconds: &longGrace},
+		Status:     v1.PodStatus{Phase: v1.PodRunning},
+	}
+	shortGracePod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "short-grace-pod", Namespace: "default"},
+		Spec:       v1.PodSpec{NodeName: "test-node", TerminationGracePeriodSeconds: &shortGrace},
+		Status:     v1.PodStatus{Phase: v1.PodRunning},
+	}
+	kubeClient.CoreV1().Pods("default").Create(context.Background(), longGracePod, metav1.CreateOptions{})
+	kubeClient.CoreV1().Pods("default").Create(context.Background(), shortGracePod, metav1.CreateOptions{})
+
+	deleted, err := deletePodsOnNode(kubeClient, "test-node", 180)
+	if err != nil {
+		t.Fatalf("deletePodsOnNode: expected no error, got: %v", err)
+	}
+
+	if deleted != 2 {
+		t.Fatalf("expected 2 pods deleted, got: %d", deleted)
+	}
+
+	remaining, _ := kubeClient.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
+	if len(remaining.Items) != 0 {
+		t.Fatalf("expected all pods deleted, but %d remain", len(remaining.Items))
+	}
+}
+
+func Test_CountActivePods(t *testing.T) {
+	t.Log("Test_CountActivePods: should count only non-daemonset, active pods")
+	kubeClient := fake.NewSimpleClientset()
+
+	pods := []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "running-pod", Namespace: "default"},
+			Spec:       v1.PodSpec{NodeName: "test-node"},
+			Status:     v1.PodStatus{Phase: v1.PodRunning},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ds-pod", Namespace: "kube-system",
+				OwnerReferences: []metav1.OwnerReference{{Kind: "DaemonSet", Name: "my-ds", APIVersion: "apps/v1"}},
+			},
+			Spec:   v1.PodSpec{NodeName: "test-node"},
+			Status: v1.PodStatus{Phase: v1.PodRunning},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "succeeded-pod", Namespace: "default"},
+			Spec:       v1.PodSpec{NodeName: "test-node"},
+			Status:     v1.PodStatus{Phase: v1.PodSucceeded},
+		},
+	}
+	for _, pod := range pods {
+		kubeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	}
+
+	count := countActivePods(kubeClient, "test-node")
+	if count != 1 {
+		t.Fatalf("expected 1 active pod, got: %d", count)
+	}
+}

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -73,6 +73,7 @@ func (mgr *Manager) Start() {
 	log.Infof("unknown node drain timeout seconds = %v", ctx.DrainTimeoutUnknownSeconds)
 	log.Infof("node drain retry interval seconds = %v", ctx.DrainRetryIntervalSeconds)
 	log.Infof("node drain retry attempts = %v", ctx.DrainRetryAttempts)
+	log.Infof("max termination grace period seconds = %v", ctx.MaxTerminationGracePeriod)
 	log.Infof("with alb deregister = %v", ctx.WithDeregister)
 	log.Infof("deregister target types = %v", ctx.DeregisterTargetTypes)
 
@@ -612,12 +613,16 @@ func (mgr *Manager) drainLoadbalancerTarget(event *LifecycleEvent) error {
 
 func (mgr *Manager) handleEvent(event *LifecycleEvent) error {
 	var (
-		asgClient = mgr.authenticator.ScalingGroupClient
-		errs      error
+		errs error
 	)
 
-	// send heartbeat at intervals
-	go sendHeartbeat(asgClient, event, mgr.context.MaxTimeToProcessSeconds)
+	go sendHeartbeat(heartbeatConfig{
+		asgClient:                 mgr.authenticator.ScalingGroupClient,
+		kubeClient:                mgr.authenticator.KubernetesClient,
+		event:                     event,
+		maxTimeToProcessSeconds:   mgr.context.MaxTimeToProcessSeconds,
+		maxTerminationGracePeriod: mgr.context.MaxTerminationGracePeriod,
+	})
 
 	// Annotate node with InProgressAnnotationKey = EventBody for resuming in case of crash
 	storeMessage, err := serializeMessage(event.message)

--- a/pkg/service/server_test.go
+++ b/pkg/service/server_test.go
@@ -35,14 +35,15 @@ func _completeEventAfter(event *LifecycleEvent, t time.Duration) {
 
 func _newBasicContext() ManagerContext {
 	return ManagerContext{
-		KubectlLocalPath:        stubKubectlPathSuccess,
-		QueueName:               "my-queue",
-		Region:                  "us-west-2",
-		DrainTimeoutSeconds:     1,
-		DrainRetryAttempts:      3,
-		PollingIntervalSeconds:  1,
-		MaxDrainConcurrency:     semaphore.NewWeighted(32),
-		MaxTimeToProcessSeconds: 3600,
+		KubectlLocalPath:          stubKubectlPathSuccess,
+		QueueName:                 "my-queue",
+		Region:                    "us-west-2",
+		DrainTimeoutSeconds:       1,
+		DrainRetryAttempts:        3,
+		PollingIntervalSeconds:    1,
+		MaxDrainConcurrency:       semaphore.NewWeighted(32),
+		MaxTimeToProcessSeconds:   3600,
+		MaxTerminationGracePeriod: 900,
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #283

- When `--max-time-to-process` is reached, lifecycle-manager now **deletes all non-daemonset pods** on the node so they receive SIGTERM and can shut down gracefully
- Continues sending heartbeats during a new configurable `--max-termination-grace-period` (default 900s / 15 min) to keep the instance alive while pods terminate
- Explicitly calls `CompleteLifecycleAction(ABANDON)` instead of silently stopping and letting AWS force-terminate the instance
- Pod deletion retries up to 3 times with backoff on transient failures

### New CLI flag

`--max-termination-grace-period` (default: `900` seconds) : how long to wait for pods to terminate after the heartbeat timeout fires, while continuing to send heartbeats to AWS.

### RBAC requirement

The `lifecycle-manager` ClusterRole needs `delete` added to the `pods` resource verbs:

    - apiGroups: [""]
      resources: ["pods"]
      verbs: ["get", "list", "delete"]   # "delete" is new

## Test plan

### Unit tests (48/48 passing)

- [x] `Test_SendHeartbeatPositive` — heartbeats sent while event is processing
- [x] `Test_SendHeartbeatNegative` — no heartbeats when event is already completed
- [x] `Test_SendHeartbeatTimeoutDeletesPods` — on timeout: pods deleted, ABANDON called, eventCompleted set
- [x] `Test_SendHeartbeatTimeoutSkipsDaemonSetPods` — DaemonSet pods preserved, regular pods deleted
- [x] `Test_IsDaemonSetPod` — correctly identifies DaemonSet-owned pods
- [x] `Test_DeletePodsOnNode` — deletes non-daemonset pods, skips daemonset pods
- [x] `Test_CountActivePods` — counts only non-daemonset, non-completed pods
- [x] All pre-existing tests pass unchanged

### End-to-end testing on live cluster

**Cluster:** `lwan3-20241112-usw2-k8s`
**Config:** `--max-time-to-process=300`, `--drain-timeout=300`, `--max-termination-grace-period=180`

**Setup:**
- Deployed a `drain-blocker` pod with a SIGTERM trap handler (`terminationGracePeriodSeconds: 120`)
- Created a `PodDisruptionBudget` with `maxUnavailable: 0` to block `kubectl drain` eviction
- This forces the drain to be stuck until the heartbeat timeout fires, exercising the new code path

**Test execution:** Terminated EC2 instance `i-0da2f2e844b8e98b9` via `aws autoscaling terminate-instance-in-auto-scaling-group`
<img width="971" height="162" alt="image" src="https://github.com/user-attachments/assets/b19d1ddf-5699-449b-977f-22b3f747aa15" />


**The lifecycle manager received the request:**
<img width="1145" height="446" alt="image" src="https://github.com/user-attachments/assets/cc267826-30e1-4980-8284-ea6fc66791e6" />


**The lifecycle manager - `Cannot evict pod... would violate the pod's disruption budget`:**
```
evicting pod dev-pattern-iksmanager-iam4/drain-blocker-5d688bd6ff-dm422
error when evicting pods/"drain-blocker-5d688bd6ff-dm422" -n "dev-pattern-iksmanager-iam4" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
evicti
```
<img width="881" height="75" alt="image" src="https://github.com/user-attachments/assets/6e9ad049-f4e0-4f9b-8709-b100e6a34e77" />



**The lifecycle manager denotes `heartbeat extended over threshold, beginning graceful pod termination` and then proceeds to delete the pod:**
<img width="897" height="100" alt="image" src="https://github.com/user-attachments/assets/64453400-6b78-4e05-b41e-4e84ac152f3e" />


**The Pod gracefully shutdown:**
<img width="862" height="65" alt="image" src="https://github.com/user-attachments/assets/35e1a4a0-cdd0-4cab-9175-a51933706709" />



**The pod `termination` events:**
<img width="989" height="226" alt="image" src="https://github.com/user-attachments/assets/375d657d-7ccb-443a-9972-55e046bde042" />



**Events from test:**
```
default   10m    Normal    LifecycleHookReceived                 lifecyclemanager   ...instance i-0720110a61c638657 will begin processing...
default   7m40s  Warning   HeartbeatTimeoutGracefulTermination   lifecyclemanager   ...instance i-0720110a61c638657 exceeded max-time-to-process, deleted 1 pods for graceful termination on node ip-10-13-14-25...
default   7m8s   Normal    NodeDrainSucceeded                    lifecyclemanager   ...node ip-10-13-14-25... has been drained successfully...
default   6m31s  Normal    NodeDrainSucceeded                    lifecyclemanager   ...node ip-10-13-14-25... has been deleted successfully...
default   6m30s  Normal    LifecycleHookProcessed                lifecyclemanager   ...instance i-0720110a61c638657 gracefully terminated after 219.84s...
```

**Results (from lifecycle-manager logs):**

| Time | Event | Log evidence |
|------|-------|-------------|
| 01:51:03 | Termination event received | `i-0da2f2e844b8e98b9> received termination event` |
| 01:51:03 | Heartbeat sent | `sending heartbeat (1/2)` |
| 01:51:04 | Drain started, blocked by PDB | `Cannot evict pod... would violate the pod's disruption budget` |
| 01:53:33 | **Timeout fired (~2.5 min)** | `heartbeat extended over threshold, beginning graceful pod termination` |
| 01:53:33 | **Pod deletion succeeded** | `deleting pod dev-pattern-iksmanager-iam4/drain-blocker-...` --> `requested deletion of 1 non-daemonset pods` |
| 01:53:34 | Waiting for pod termination | `waiting for 1 non-daemonset pods to terminate` |
| 01:54:05 | Drain unblocked (pod deleted) | `drain succeeded, node ip-10-13-14-72` |
| 01:54:27 | Node deleted, event completed | `event completed after 203.28s` with `CONTINUE` |
| 01:56:04 | Grace period cleanup | `all non-daemonset pods terminated` --> `completing lifecycle action with ABANDON` |





**Pod status transitions (from `kubectl get pod -w`):**

    drain-blocker-5d688bd6ff-dm422   1/1   Running       0     10m
    drain-blocker-5d688bd6ff-dm422   1/1   Terminating   0     14m    --> SIGTERM sent by our code
    drain-blocker-5d688bd6ff-dm422   0/1   Completed     0     15m   --> graceful shutdown finished

**Pod logs (proof of graceful shutdown):**

    Pod started at Thu Apr  9 01:38:41 UTC 2026
    SIGTERM received at Thu Apr  9 01:53:34 UTC 2026
    shutting down gracefully

**Key validations:**
- [x] Pod received SIGTERM (not force-killed) — confirmed by `SIGTERM received` in pod logs
- [x] DaemonSet pods (aws-node, kube-proxy, calico-node, etc.) were correctly skipped
- [x] `CompleteLifecycleAction(ABANDON)` called explicitly — confirmed in logs
- [x] Heartbeats continued during grace period to keep instance alive
- [x] PDB-blocked drain was bypassed by direct pod deletion
- [x] Node was properly deleted from cluster after processing
- [x] Replacement pod scheduled on a healthy node automatically
