### PR TITLE
refactor: enhance heartbeat logic and add escalation for drain failures

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -146,15 +146,15 @@ func validateServeConfig() error {
 
 	// Ensure --max-time-to-process is large enough to outlive the worst-case
 	// main-path duration: drain-retries x drain-timeout (drain exhaustion) plus
-	// max-termination-grace-period plus a 30s slack. If it is not, the heartbeat
-	// goroutine could exit while drainNodeTarget is still inside the graceful
-	// force-delete escalation, causing the AWS lifecycle hook to time out and
-	// ABANDON the instance.
-	const maxTimeSlackSeconds int64 = 30
-	ceiling := int64(drainRetryAttempts)*int64(drainTimeoutSeconds) + maxTerminationGracePeriod + maxTimeSlackSeconds
+	// max-termination-grace-period plus the escalation wait slack. If it is not,
+	// the heartbeat goroutine could exit while drainNodeTarget is still inside
+	// the graceful force-delete escalation, causing the AWS lifecycle hook to
+	// time out and ABANDON the instance.
+	drainFailureWaitSlackSeconds := service.EscalateDrainFailureWaitSlackSeconds
+	ceiling := int64(drainRetryAttempts)*int64(drainTimeoutSeconds) + maxTerminationGracePeriod + drainFailureWaitSlackSeconds
 	if maxTimeToProcessSeconds < ceiling {
-		return fmt.Errorf("--max-time-to-process (%ds) must be >= (drain-retries x drain-timeout) + max-termination-grace-period + 30s = %ds",
-			maxTimeToProcessSeconds, ceiling)
+		return fmt.Errorf("--max-time-to-process (%ds) must be >= (drain-retries x drain-timeout) + max-termination-grace-period + %ds = %ds",
+			maxTimeToProcessSeconds, drainFailureWaitSlackSeconds, ceiling)
 	}
 	return nil
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -39,8 +39,8 @@ var (
 	drainTimeoutUnknownSeconds int
 	drainRetryAttempts         int
 	pollingIntervalSeconds     int
-	maxTimeToProcessSeconds       int64
-	maxTerminationGracePeriod     int64
+	maxTimeToProcessSeconds    int64
+	maxTerminationGracePeriod  int64
 
 	// DefaultRetryer is the default retry configuration for some AWS API calls
 	DefaultRetryer = client.DefaultRetryer{
@@ -116,30 +116,51 @@ func init() {
 	serveCmd.Flags().BoolVar(&refreshExpiredCredentials, "refresh-expired-credentials", false, "refreshes expired credentials (requires shared credentials file)")
 }
 
-func validateServe() {
+// validateServeConfig returns a descriptive error if serve flags are invalid.
+func validateServeConfig() error {
 	if localMode != "" {
 		if _, err := os.Stat(localMode); os.IsNotExist(err) {
-			log.Fatalf("provided kubeconfig path does not exist")
+			return fmt.Errorf("provided kubeconfig path does not exist")
 		}
 	}
 
 	if kubectlLocalPath != "" {
 		if _, err := os.Stat(kubectlLocalPath); os.IsNotExist(err) {
-			log.Fatalf("provided kubectl path does not exist")
+			return fmt.Errorf("provided kubectl path does not exist")
 		}
 	} else {
-		log.Fatalf("must provide kubectl path")
+		return fmt.Errorf("must provide kubectl path")
 	}
 
 	if region == "" {
-		log.Fatalf("must provide valid AWS region name")
+		return fmt.Errorf("must provide valid AWS region name")
 	}
 
 	if queueName == "" {
-		log.Fatalf("must provide valid SQS queue name")
+		return fmt.Errorf("must provide valid SQS queue name")
 	}
 
 	if maxDrainConcurrency < 1 {
-		log.Fatalf("--max-drain-concurrency must be set to a value higher than 0")
+		return fmt.Errorf("--max-drain-concurrency must be set to a value higher than 0")
+	}
+
+	// Ensure --max-time-to-process is large enough to outlive the worst-case
+	// main-path duration: drain-retries x drain-timeout (drain exhaustion) plus
+	// max-termination-grace-period plus a 30s slack. If it is not, the heartbeat
+	// goroutine could exit while drainNodeTarget is still inside the graceful
+	// force-delete escalation, causing the AWS lifecycle hook to time out and
+	// ABANDON the instance.
+	const maxTimeSlackSeconds int64 = 30
+	ceiling := int64(drainRetryAttempts)*int64(drainTimeoutSeconds) + maxTerminationGracePeriod + maxTimeSlackSeconds
+	if maxTimeToProcessSeconds < ceiling {
+		return fmt.Errorf("--max-time-to-process (%ds) must be >= (drain-retries x drain-timeout) + max-termination-grace-period + 30s = %ds",
+			maxTimeToProcessSeconds, ceiling)
+	}
+	return nil
+}
+
+func validateServe() {
+	if err := validateServeConfig(); err != nil {
+		log.Fatalf("%v", err)
 	}
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -87,7 +87,7 @@ func Test_validateServeConfig_maxTimeBelowCeiling(t *testing.T) {
 	maxTimeToProcessSeconds = 10800
 
 	if err := validateServeConfig(); err == nil {
-		t.Fatal("expected error when max-time-to-process is below ceiling (11730s)")
+		t.Fatal("expected error when max-time-to-process is below ceiling (3×3600 + 900 + EscalateDrainFailureWaitSlackSeconds)")
 	}
 }
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// serveFlagGlobals captures package-level serve flags for restore between tests.
+type serveFlagGlobals struct {
+	localMode, region, queueName, kubectlLocalPath string
+	maxDrainConcurrency                            int64
+	drainTimeoutSeconds                            int
+	drainRetryAttempts                             int
+	maxTerminationGracePeriod                      int64
+	maxTimeToProcessSeconds                        int64
+}
+
+func captureServeFlagGlobals() serveFlagGlobals {
+	return serveFlagGlobals{
+		localMode:                 localMode,
+		region:                    region,
+		queueName:                 queueName,
+		kubectlLocalPath:          kubectlLocalPath,
+		maxDrainConcurrency:       maxDrainConcurrency,
+		drainTimeoutSeconds:       drainTimeoutSeconds,
+		drainRetryAttempts:        drainRetryAttempts,
+		maxTerminationGracePeriod: maxTerminationGracePeriod,
+		maxTimeToProcessSeconds:   maxTimeToProcessSeconds,
+	}
+}
+
+func restoreServeFlagGlobals(s serveFlagGlobals) {
+	localMode = s.localMode
+	region = s.region
+	queueName = s.queueName
+	kubectlLocalPath = s.kubectlLocalPath
+	maxDrainConcurrency = s.maxDrainConcurrency
+	drainTimeoutSeconds = s.drainTimeoutSeconds
+	drainRetryAttempts = s.drainRetryAttempts
+	maxTerminationGracePeriod = s.maxTerminationGracePeriod
+	maxTimeToProcessSeconds = s.maxTimeToProcessSeconds
+}
+
+func Test_validateServeConfig_defaultsSatisfyCeiling(t *testing.T) {
+	snap := captureServeFlagGlobals()
+	defer restoreServeFlagGlobals(snap)
+
+	kubectl := filepath.Join(t.TempDir(), "kubectl-bin")
+	if err := os.WriteFile(kubectl, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Align with CLI defaults from serveCmd flags (see serve.go init).
+	localMode = ""
+	kubectlLocalPath = kubectl
+	region = "us-west-2"
+	queueName = "test-queue"
+	maxDrainConcurrency = 32
+	drainRetryAttempts = 3
+	drainTimeoutSeconds = 300
+	maxTerminationGracePeriod = 900
+	maxTimeToProcessSeconds = 3600
+
+	if err := validateServeConfig(); err != nil {
+		t.Fatalf("expected default-derived ceiling to pass: %v", err)
+	}
+}
+
+func Test_validateServeConfig_maxTimeBelowCeiling(t *testing.T) {
+	snap := captureServeFlagGlobals()
+	defer restoreServeFlagGlobals(snap)
+
+	kubectl := filepath.Join(t.TempDir(), "kubectl-bin")
+	if err := os.WriteFile(kubectl, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	localMode = ""
+	kubectlLocalPath = kubectl
+	region = "us-west-2"
+	queueName = "q"
+	maxDrainConcurrency = 32
+	drainRetryAttempts = 3
+	drainTimeoutSeconds = 3600
+	maxTerminationGracePeriod = 900
+	maxTimeToProcessSeconds = 10800
+
+	if err := validateServeConfig(); err == nil {
+		t.Fatal("expected error when max-time-to-process is below ceiling (11730s)")
+	}
+}
+
+func Test_validateServeConfig_maxTimeAtExactCeiling(t *testing.T) {
+	snap := captureServeFlagGlobals()
+	defer restoreServeFlagGlobals(snap)
+
+	kubectl := filepath.Join(t.TempDir(), "kubectl-bin")
+	if err := os.WriteFile(kubectl, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	localMode = ""
+	kubectlLocalPath = kubectl
+	region = "us-west-2"
+	queueName = "q"
+	maxDrainConcurrency = 32
+	drainRetryAttempts = 3
+	drainTimeoutSeconds = 3600
+	maxTerminationGracePeriod = 900
+	maxTimeToProcessSeconds = 11730
+
+	if err := validateServeConfig(); err != nil {
+		t.Fatalf("expected max-time exactly at ceiling to pass: %v", err)
+	}
+}
+
+func Test_validateServeConfig_missingRegion(t *testing.T) {
+	snap := captureServeFlagGlobals()
+	defer restoreServeFlagGlobals(snap)
+
+	kubectl := filepath.Join(t.TempDir(), "kubectl-bin")
+	if err := os.WriteFile(kubectl, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	region = ""
+	queueName = "q"
+	kubectlLocalPath = kubectl
+	maxDrainConcurrency = 32
+	maxTimeToProcessSeconds = 100000
+	drainRetryAttempts = 3
+	drainTimeoutSeconds = 300
+	maxTerminationGracePeriod = 900
+
+	if err := validateServeConfig(); err == nil {
+		t.Fatal("expected error for empty region")
+	}
+}
+
+func Test_validateServeConfig_maxDrainConcurrencyZero(t *testing.T) {
+	snap := captureServeFlagGlobals()
+	defer restoreServeFlagGlobals(snap)
+
+	kubectl := filepath.Join(t.TempDir(), "kubectl-bin")
+	if err := os.WriteFile(kubectl, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	region = "us-west-2"
+	queueName = "q"
+	kubectlLocalPath = kubectl
+	maxDrainConcurrency = 0
+	maxTimeToProcessSeconds = 100000
+	drainRetryAttempts = 3
+	drainTimeoutSeconds = 300
+	maxTerminationGracePeriod = 900
+
+	if err := validateServeConfig(); err == nil {
+		t.Fatal("expected error for max-drain-concurrency < 1")
+	}
+}

--- a/pkg/service/autoscaling.go
+++ b/pkg/service/autoscaling.go
@@ -7,24 +7,24 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
-	iebackoff "github.com/keikoproj/inverse-exp-backoff"
 	"github.com/keikoproj/lifecycle-manager/pkg/log"
-	"k8s.io/client-go/kubernetes"
 )
 
 type heartbeatConfig struct {
-	asgClient                 autoscalingiface.AutoScalingAPI
-	kubeClient                kubernetes.Interface
-	event                     *LifecycleEvent
-	maxTimeToProcessSeconds   int64
-	maxTerminationGracePeriod int64
+	asgClient               autoscalingiface.AutoScalingAPI
+	event                   *LifecycleEvent
+	maxTimeToProcessSeconds int64
 }
 
+// sendHeartbeat keeps the AWS lifecycle hook alive by periodically calling
+// RecordLifecycleActionHeartbeat. It exits when the main goroutine sets
+// event.eventCompleted (via CompleteEvent or FailEvent), when extendLifecycleAction
+// fails (e.g., the hook has been completed/abandoned by another path), or when
+// the safety cap maxTimeToProcessSeconds is reached.
 func sendHeartbeat(cfg heartbeatConfig) {
 	var (
 		event               = cfg.event
 		client              = cfg.asgClient
-		iterationCount      = 0
 		interval            = event.heartbeatInterval
 		instanceID          = event.EC2InstanceID
 		scalingGroupName    = event.AutoScalingGroupName
@@ -33,111 +33,29 @@ func sendHeartbeat(cfg heartbeatConfig) {
 
 	log.Debugf("scaling-group = %v, maxInterval = %v, heartbeat = %v", scalingGroupName, interval, recommendedInterval)
 
-	maxIterations := int(cfg.maxTimeToProcessSeconds / recommendedInterval)
-
 	startTime := time.Now()
+	deadline := startTime.Add(time.Duration(cfg.maxTimeToProcessSeconds) * time.Second)
 
+	iterationCount := 0
 	for {
-		iterationCount++
-		if iterationCount >= maxIterations {
-			elapsed := time.Since(startTime).Round(time.Second)
-			log.Warnf("%v> heartbeat extended over threshold after %v, beginning graceful pod termination", instanceID, elapsed)
-			handleHeartbeatTimeout(cfg)
-			return
-		}
-
 		if event.eventCompleted {
 			return
 		}
+		if time.Now().After(deadline) {
+			elapsed := time.Since(startTime).Round(time.Second)
+			log.Warnf("%v> heartbeat reached max-time-to-process safety cap after %v; stopping heartbeats (main goroutine appears stuck)", instanceID, elapsed)
+			return
+		}
 
-		log.Infof("%v> sending heartbeat (%v/%v)", instanceID, iterationCount, maxIterations)
-		err := extendLifecycleAction(client, *event)
-		if err != nil {
+		iterationCount++
+		log.Infof("%v> sending heartbeat (iteration %v)", instanceID, iterationCount)
+		if err := extendLifecycleAction(client, *event); err != nil {
 			log.Errorf("%v> failed to send heartbeat for event: %v", instanceID, err)
 			return
 		}
+
 		time.Sleep(time.Duration(recommendedInterval) * time.Second)
 	}
-}
-
-func handleHeartbeatTimeout(cfg heartbeatConfig) {
-	var (
-		event      = cfg.event
-		client     = cfg.asgClient
-		kubeClient = cfg.kubeClient
-		instanceID = event.EC2InstanceID
-		nodeName   = event.referencedNode.Name
-	)
-
-	deleted, err := deletePodsOnNode(kubeClient, nodeName, cfg.maxTerminationGracePeriod)
-	if err != nil {
-		log.Errorf("%v> failed to delete pods on node %s: %v", instanceID, nodeName, err)
-	} else {
-		log.Infof("%v> requested deletion of %d non-daemonset pods on node %s", instanceID, deleted, nodeName)
-	}
-
-	msg := fmt.Sprintf(EventMessageHeartbeatTimeoutGracefulTermination, instanceID, deleted, nodeName)
-	kEvent := newKubernetesEvent(EventReasonHeartbeatTimeoutGracefulTermination, getMessageFields(event, msg))
-	publishKubernetesEvent(kubeClient, kEvent)
-
-	waitForPodsWithHeartbeat(cfg)
-
-	if event.eventCompleted {
-		log.Infof("%v> event already completed by main goroutine, skipping ABANDON", instanceID)
-	} else {
-		log.Warnf("%v> completing lifecycle action with ABANDON after timeout", instanceID)
-		if err := completeLifecycleAction(client, *event, AbandonAction); err != nil {
-			log.Errorf("%v> failed to complete lifecycle action with ABANDON: %v", instanceID, err)
-		}
-	}
-
-	event.SetEventCompleted(true)
-}
-
-func waitForPodsWithHeartbeat(cfg heartbeatConfig) {
-	var (
-		event      = cfg.event
-		client     = cfg.asgClient
-		kubeClient = cfg.kubeClient
-		instanceID = event.EC2InstanceID
-		nodeName   = event.referencedNode.Name
-		timeout    = time.Duration(cfg.maxTerminationGracePeriod) * time.Second
-		maxDelay   = WaiterMaxDelay
-		minDelay   = WaiterMinDelay
-	)
-
-	if timeout <= 0 {
-		return
-	}
-	if maxDelay > timeout {
-		maxDelay = timeout / 2
-	}
-	if minDelay > maxDelay {
-		minDelay = maxDelay
-	}
-
-	ieb, err := iebackoff.NewIEBWithTimeout(maxDelay, minDelay, timeout, 0.5, time.Now())
-	if err != nil {
-		log.Errorf("%v> failed to create inverse-exp-backoff: %v", instanceID, err)
-		return
-	}
-
-	for ; err == nil; err = ieb.Next() {
-		if err := extendLifecycleAction(client, *event); err != nil {
-			log.Errorf("%v> failed to send heartbeat during termination grace period: %v", instanceID, err)
-		}
-
-		active := countActivePods(kubeClient, nodeName)
-		if active == 0 {
-			log.Infof("%v> all non-daemonset pods terminated on node %s", instanceID, nodeName)
-			return
-		}
-		if active > 0 {
-			log.Infof("%v> waiting for %d non-daemonset pods to terminate on node %s", instanceID, active, nodeName)
-		}
-	}
-
-	log.Warnf("%v> termination grace period expired with pods still running on node %s", instanceID, nodeName)
 }
 
 func getHookHeartbeatInterval(client autoscalingiface.AutoScalingAPI, lifecycleHookName, scalingGroupName string) (int64, error) {

--- a/pkg/service/autoscaling_test.go
+++ b/pkg/service/autoscaling_test.go
@@ -1,16 +1,12 @@
 package service
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 type stubAutoscaling struct {
@@ -46,9 +42,8 @@ func (e *LifecycleEvent) _setEventCompletedAfter(value bool, seconds int64) {
 }
 
 func Test_SendHeartbeatPositive(t *testing.T) {
-	t.Log("Test_SendHeartbeatPositive: If drain is not complete, a heartbeat should be sent")
+	t.Log("Test_SendHeartbeatPositive: If event is not completed, heartbeats should be sent until eventCompleted is set")
 	stubber := &stubAutoscaling{}
-	kubeClient := fake.NewSimpleClientset()
 	event := &LifecycleEvent{
 		AutoScalingGroupName: "my-asg",
 		EC2InstanceID:        "i-1234567890",
@@ -60,23 +55,23 @@ func Test_SendHeartbeatPositive(t *testing.T) {
 
 	go event._setEventCompletedAfter(true, 2)
 	sendHeartbeat(heartbeatConfig{
-		asgClient:                 stubber,
-		kubeClient:                kubeClient,
-		event:                     event,
-		maxTimeToProcessSeconds:   3600,
-		maxTerminationGracePeriod: 900,
+		asgClient:               stubber,
+		event:                   event,
+		maxTimeToProcessSeconds: 3600,
 	})
 	expectedHeartbeatCalls := 3
 
 	if stubber.timesCalledRecordLifecycleActionHeartbeat != expectedHeartbeatCalls {
 		t.Fatalf("expected timesCalledRecordLifecycleActionHeartbeat: %v, got: %v", expectedHeartbeatCalls, stubber.timesCalledRecordLifecycleActionHeartbeat)
 	}
+	if stubber.timesCalledCompleteLifecycleAction != 0 {
+		t.Fatalf("expected sendHeartbeat NOT to call CompleteLifecycleAction, got: %v calls", stubber.timesCalledCompleteLifecycleAction)
+	}
 }
 
 func Test_SendHeartbeatNegative(t *testing.T) {
-	t.Log("Test_SendHeartbeatNegative: If event is completed, heartbeat should not be sent")
+	t.Log("Test_SendHeartbeatNegative: If event is already completed, heartbeat should not be sent")
 	stubber := &stubAutoscaling{}
-	kubeClient := fake.NewSimpleClientset()
 	event := &LifecycleEvent{
 		AutoScalingGroupName: "my-asg",
 		EC2InstanceID:        "i-1234567890",
@@ -87,11 +82,9 @@ func Test_SendHeartbeatNegative(t *testing.T) {
 	}
 
 	sendHeartbeat(heartbeatConfig{
-		asgClient:                 stubber,
-		kubeClient:                kubeClient,
-		event:                     event,
-		maxTimeToProcessSeconds:   3600,
-		maxTerminationGracePeriod: 900,
+		asgClient:               stubber,
+		event:                   event,
+		maxTimeToProcessSeconds: 3600,
 	})
 	expectedHeartbeatCalls := 0
 
@@ -100,118 +93,37 @@ func Test_SendHeartbeatNegative(t *testing.T) {
 	}
 }
 
-func Test_SendHeartbeatTimeoutDeletesPods(t *testing.T) {
-	t.Log("Test_SendHeartbeatTimeoutDeletesPods: When max-time-to-process is reached, pods should be deleted and ABANDON called")
+func Test_SendHeartbeatExitsAtMaxTimeToProcess(t *testing.T) {
+	t.Log("Test_SendHeartbeatExitsAtMaxTimeToProcess: when max-time-to-process safety cap is reached, heartbeat exits without calling CompleteLifecycleAction")
 	stubber := &stubAutoscaling{}
-	kubeClient := fake.NewSimpleClientset()
-
-	node := &v1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
-		Spec:       v1.NodeSpec{ProviderID: "aws:///us-west-2a/i-1234567890"},
-	}
-	kubeClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
-
-	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod",
-			Namespace: "default",
-		},
-		Spec: v1.PodSpec{NodeName: "test-node"},
-	}
-	kubeClient.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{})
-
 	event := &LifecycleEvent{
 		AutoScalingGroupName: "my-asg",
 		EC2InstanceID:        "i-1234567890",
 		LifecycleActionToken: "some-token-1234",
 		LifecycleHookName:    "my-hook",
 		heartbeatInterval:    2,
-		referencedNode:       *node,
 	}
 
+	start := time.Now()
 	sendHeartbeat(heartbeatConfig{
-		asgClient:                 stubber,
-		kubeClient:                kubeClient,
-		event:                     event,
-		maxTimeToProcessSeconds:   1,
-		maxTerminationGracePeriod: 1,
+		asgClient:               stubber,
+		event:                   event,
+		maxTimeToProcessSeconds: 1,
 	})
+	elapsed := time.Since(start)
 
-	if !event.eventCompleted {
-		t.Fatal("expected eventCompleted to be true after timeout")
+	if stubber.timesCalledCompleteLifecycleAction != 0 {
+		t.Fatalf("expected sendHeartbeat NOT to call CompleteLifecycleAction, got: %v calls", stubber.timesCalledCompleteLifecycleAction)
 	}
-
-	if stubber.timesCalledCompleteLifecycleAction != 1 {
-		t.Fatalf("expected CompleteLifecycleAction called once, got: %v", stubber.timesCalledCompleteLifecycleAction)
+	if event.eventCompleted {
+		t.Fatal("expected event.eventCompleted to remain false (sendHeartbeat must not own the termination decision)")
 	}
-
-	if stubber.lastCompleteAction != AbandonAction {
-		t.Fatalf("expected ABANDON action, got: %v", stubber.lastCompleteAction)
+	// The heartbeat may send 1 heartbeat before the deadline check sees expiry on the next loop iteration.
+	if stubber.timesCalledRecordLifecycleActionHeartbeat > 1 {
+		t.Fatalf("expected at most 1 heartbeat before safety cap fires, got: %v", stubber.timesCalledRecordLifecycleActionHeartbeat)
 	}
-
-	pods, _ := kubeClient.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
-	if len(pods.Items) != 0 {
-		t.Fatalf("expected pod to be deleted, but %d pods remain", len(pods.Items))
-	}
-}
-
-func Test_SendHeartbeatTimeoutSkipsDaemonSetPods(t *testing.T) {
-	t.Log("Test_SendHeartbeatTimeoutSkipsDaemonSetPods: DaemonSet pods should not be deleted on timeout")
-	stubber := &stubAutoscaling{}
-	kubeClient := fake.NewSimpleClientset()
-
-	node := &v1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
-		Spec:       v1.NodeSpec{ProviderID: "aws:///us-west-2a/i-1234567890"},
-	}
-	kubeClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
-
-	dsPod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ds-pod",
-			Namespace: "kube-system",
-			OwnerReferences: []metav1.OwnerReference{
-				{Kind: "DaemonSet", Name: "my-ds", APIVersion: "apps/v1"},
-			},
-		},
-		Spec: v1.PodSpec{NodeName: "test-node"},
-	}
-	kubeClient.CoreV1().Pods("kube-system").Create(context.Background(), dsPod, metav1.CreateOptions{})
-
-	regularPod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "regular-pod",
-			Namespace: "default",
-		},
-		Spec: v1.PodSpec{NodeName: "test-node"},
-	}
-	kubeClient.CoreV1().Pods("default").Create(context.Background(), regularPod, metav1.CreateOptions{})
-
-	event := &LifecycleEvent{
-		AutoScalingGroupName: "my-asg",
-		EC2InstanceID:        "i-1234567890",
-		LifecycleActionToken: "some-token-1234",
-		LifecycleHookName:    "my-hook",
-		heartbeatInterval:    2,
-		referencedNode:       *node,
-	}
-
-	sendHeartbeat(heartbeatConfig{
-		asgClient:                 stubber,
-		kubeClient:                kubeClient,
-		event:                     event,
-		maxTimeToProcessSeconds:   1,
-		maxTerminationGracePeriod: 1,
-	})
-
-	dsPods, _ := kubeClient.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{})
-	if len(dsPods.Items) != 1 {
-		t.Fatalf("expected daemonset pod to survive, but got %d pods", len(dsPods.Items))
-	}
-
-	regularPods, _ := kubeClient.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
-	if len(regularPods.Items) != 0 {
-		t.Fatalf("expected regular pod to be deleted, but got %d pods", len(regularPods.Items))
+	if elapsed > 5*time.Second {
+		t.Fatalf("expected sendHeartbeat to exit promptly after safety cap, took: %v", elapsed)
 	}
 }
 

--- a/pkg/service/e2e-ip-fmea2-results-v2.39.15.md
+++ b/pkg/service/e2e-ip-fmea2-results-v2.39.15.md
@@ -1,0 +1,374 @@
+---
+
+## Test 3: Second FMEA overnight test (April 23, 2026)
+
+Independent repeat run on the same `ip-fmea1-e2e-usw2-k8s` cluster, different instance and node, confirms the graceful-termination path is repeatable under identical production-like settings.
+
+### Setup
+```
+lifecycle manager image used: docker.intuit.com/docker-rmt/keikoproj/lifecycle-manager:v0.6.6
+cluster: ip-fmea1-e2e-usw2-k8s
+namespace: sandbox-sandbox-draychevcustgitprima-usw2-e2e
+pod: drain-blocker-54c6f7cc8c-mlvmw
+    running on node: ip-10-235-117-80.us-west-2.compute.internal
+Instance id: i-0d3dbac803fff8c33
+ASG: ip-fmea1-e2e-usw2-k8s-instance-manager-nodes
+Availability Zone: us-west-2c (usw2-az3)
+Termination initiated: 2026-04-23T06:01:27Z (user-requested scale-in)
+
+container settings:
+     containers:
+      - command:
+        - /bin/lifecycle-manager
+        - serve
+        - --queue-name=ip-fmea1-e2e-usw2-k8s-lifecycle-manager
+        - --region=us-west-2
+        - --polling-interval=10
+        - --drain-timeout=3600
+        - --drain-timeout-unknown=60
+        - --max-time-to-process=10800
+        - --max-drain-concurrency=32
+        - --max-termination-grace-period=900
+        - --with-deregister=true
+        - --deregister-target-types=classic-elb,target-group
+        - --log-level=debug
+        env:
+        - name: AWS_USE_FIPS_ENDPOINT
+          value: "true"
+        image: docker.intuit.com/docker-rmt/keikoproj/lifecycle-manager:v0.6.6
+        imagePullPolicy: Always
+        name: lifecycle-manager
+```
+
+### Test Result
+
+**Event — full heartbeat-timeout graceful termination (~3h)**
+```
+06:01:28  Event received, drain starts (blocked by PDB)
+          Heartbeats every 2.5 min (1/72 through 71/72)
+          Drain retrying for ~3 hours...
+          (drain-timeout retries visible at ~07:01:33 and ~08:01:38)
+
+08:59:07  Heartbeat 72/72 → TIMEOUT after 2h57m39s
+          → deleting pod (grace period: 600s — pod's 600s within 900s global cap)
+          → requested deletion of 1 non-daemonset pods
+          → publishing event: HeartbeatTimeoutGracefulTermination
+
+08:59:39  Drain succeeded (pod deletion unblocked the PDB)
+08:59:59  Node deleted, event completed with CONTINUE (total: 10710.93s ≈ 2h58m31s)
+09:00:37  "event already completed by main goroutine, skipping ABANDON"
+```
+
+### Validation matrix
+| Check | Evidence | Result |
+|---|---|---|
+| Event received | `i-0d3dbac803fff8c33> received termination event` at 06:01:28Z | Pass |
+| 71 heartbeats over ~3 h | `sending heartbeat (1/72)` → `(71/72)` at 2.5 min intervals | Pass |
+| PDB blocked drain | `Cannot evict pod ... disruption budget` retries for ~3 hours | Pass |
+| Timeout fired at correct time | `heartbeat extended over threshold after 2h57m39s` at 08:59:07Z | Pass |
+| Grace period within cap | `(grace period: 600s)` — pod had 600s, global cap 900s | Pass |
+| K8s event published | `publishing event: HeartbeatTimeoutGracefulTermination` | Pass |
+| Drain unblocked | `drain succeeded` at 08:59:39Z | Pass |
+| LB deregister | Scanned target groups + classic ELBs, 0 active targets | Pass |
+| Node deleted | `completed node deletion` at 08:59:59Z | Pass |
+| Event completed with CONTINUE | `setting lifecycle event as completed with result: CONTINUE` | Pass |
+| Total time | `10710.93s` (≈ 2h58m31s) | Pass |
+| ABANDON race guarded | `event already completed by main goroutine, skipping ABANDON` | Pass |
+
+### AWS Scale-in Activity
+```json
+{
+    "Activity": {
+        "ActivityId": "0de676e3-b756-0ebd-beda-a29764aec760",
+        "AutoScalingGroupName": "ip-fmea1-e2e-usw2-k8s-instance-manager-nodes",
+        "Description": "Terminating EC2 instance: i-0d3dbac803fff8c33",
+        "Cause": "At 2026-04-23T06:01:27Z instance i-0d3dbac803fff8c33 was taken out of service in response to a user request.",
+        "StartTime": "2026-04-23T06:01:27.683000+00:00",
+        "StatusCode": "InProgress",
+        "Progress": 0,
+        "Details": "{\"Availability Zone ID\":\"usw2-az3\",\"Subnet ID\":\"subnet-0a9f4a492da03e0fa\",\"Availability Zone\":\"us-west-2c\"}"
+    }
+}
+```
+
+### Lifecycle manager logs
+```
+kubectl logs lifecycle-manager-744c89cf46-wqpsv -n addon-lifecycle-manager-ns | grep -E "received termination|heartbeat|threshold|deleting pod|requested deletion|ABANDON|CONTINUE|completed|skipping|grace period|publishing event"
+time="2026-04-23T06:01:28Z" level=info msg="i-0d3dbac803fff8c33> received termination event"
+time="2026-04-23T06:01:28Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (1/72)"
+time="2026-04-23T06:03:58Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (2/72)"
+time="2026-04-23T06:06:28Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (3/72)"
+time="2026-04-23T06:08:59Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (4/72)"
+time="2026-04-23T06:11:29Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (5/72)"
+time="2026-04-23T06:13:59Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (6/72)"
+time="2026-04-23T06:16:29Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (7/72)"
+time="2026-04-23T06:18:59Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (8/72)"
+time="2026-04-23T06:21:29Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (9/72)"
+time="2026-04-23T06:23:59Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (10/72)"
+time="2026-04-23T06:26:30Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (11/72)"
+time="2026-04-23T06:29:00Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (12/72)"
+time="2026-04-23T06:31:30Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (13/72)"
+time="2026-04-23T06:34:00Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (14/72)"
+time="2026-04-23T06:36:30Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (15/72)"
+time="2026-04-23T06:39:00Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (16/72)"
+time="2026-04-23T06:41:30Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (17/72)"
+time="2026-04-23T06:44:00Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (18/72)"
+time="2026-04-23T06:46:31Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (19/72)"
+time="2026-04-23T06:49:01Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (20/72)"
+time="2026-04-23T06:51:31Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (21/72)"
+time="2026-04-23T06:54:01Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (22/72)"
+time="2026-04-23T06:56:31Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (23/72)"
+time="2026-04-23T06:59:01Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (24/72)"
+time="2026-04-23T07:01:31Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (25/72)"
+time="2026-04-23T07:04:01Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (26/72)"
+time="2026-04-23T07:06:32Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (27/72)"
+time="2026-04-23T07:09:02Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (28/72)"
+time="2026-04-23T07:11:32Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (29/72)"
+time="2026-04-23T07:14:02Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (30/72)"
+time="2026-04-23T07:16:32Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (31/72)"
+time="2026-04-23T07:19:02Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (32/72)"
+time="2026-04-23T07:21:32Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (33/72)"
+time="2026-04-23T07:24:02Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (34/72)"
+time="2026-04-23T07:26:33Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (35/72)"
+time="2026-04-23T07:29:03Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (36/72)"
+time="2026-04-23T07:31:33Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (37/72)"
+time="2026-04-23T07:34:03Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (38/72)"
+time="2026-04-23T07:36:33Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (39/72)"
+time="2026-04-23T07:39:03Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (40/72)"
+time="2026-04-23T07:41:33Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (41/72)"
+time="2026-04-23T07:44:04Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (42/72)"
+time="2026-04-23T07:46:34Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (43/72)"
+time="2026-04-23T07:49:04Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (44/72)"
+time="2026-04-23T07:51:34Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (45/72)"
+time="2026-04-23T07:54:04Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (46/72)"
+time="2026-04-23T07:56:34Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (47/72)"
+time="2026-04-23T07:59:04Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (48/72)"
+time="2026-04-23T08:01:34Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (49/72)"
+time="2026-04-23T08:04:05Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (50/72)"
+time="2026-04-23T08:06:35Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (51/72)"
+time="2026-04-23T08:09:05Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (52/72)"
+time="2026-04-23T08:11:35Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (53/72)"
+time="2026-04-23T08:14:05Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (54/72)"
+time="2026-04-23T08:16:35Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (55/72)"
+time="2026-04-23T08:19:05Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (56/72)"
+time="2026-04-23T08:21:35Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (57/72)"
+time="2026-04-23T08:24:05Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (58/72)"
+time="2026-04-23T08:26:36Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (59/72)"
+time="2026-04-23T08:29:06Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (60/72)"
+time="2026-04-23T08:31:36Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (61/72)"
+time="2026-04-23T08:34:06Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (62/72)"
+time="2026-04-23T08:36:36Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (63/72)"
+time="2026-04-23T08:39:06Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (64/72)"
+time="2026-04-23T08:41:36Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (65/72)"
+time="2026-04-23T08:44:07Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (66/72)"
+time="2026-04-23T08:46:37Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (67/72)"
+time="2026-04-23T08:49:07Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (68/72)"
+time="2026-04-23T08:51:37Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (69/72)"
+time="2026-04-23T08:54:07Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (70/72)"
+time="2026-04-23T08:56:37Z" level=info msg="i-0d3dbac803fff8c33> sending heartbeat (71/72)"
+time="2026-04-23T08:59:07Z" level=warning msg="i-0d3dbac803fff8c33> heartbeat extended over threshold after 2h57m39s, beginning graceful pod termination"
+time="2026-04-23T08:59:07Z" level=info msg="deleting pod sandbox-sandbox-draychevcustgitprima-usw2-e2e/drain-blocker-54c6f7cc8c-mlvmw on node ip-10-235-117-80.us-west-2.compute.internal (grace period: 600s)"
+time="2026-04-23T08:59:07Z" level=info msg="i-0d3dbac803fff8c33> requested deletion of 1 non-daemonset pods on node ip-10-235-117-80.us-west-2.compute.internal"
+time="2026-04-23T08:59:07Z" level=debug msg="publishing event: HeartbeatTimeoutGracefulTermination"
+time="2026-04-23T08:59:07Z" level=info msg="i-0d3dbac803fff8c33> waiting for 1 non-daemonset pods to terminate on node ip-10-235-117-80.us-west-2.compute.internal"
+time="2026-04-23T08:59:39Z" level=info msg="drain succeeded, node ip-10-235-117-80.us-west-2.compute.internal"
+time="2026-04-23T08:59:39Z" level=info msg="i-0d3dbac803fff8c33> completed drain for node/ip-10-235-117-80.us-west-2.compute.internal"
+time="2026-04-23T08:59:59Z" level=info msg="i-0d3dbac803fff8c33> completed node deletion/ip-10-235-117-80.us-west-2.compute.internal"
+time="2026-04-23T08:59:59Z" level=info msg="i-0d3dbac803fff8c33> setting lifecycle event as completed with result: CONTINUE"
+time="2026-04-23T08:59:59Z" level=info msg="event fc367673-268e-b16d-e939-f4635880b866 for instance i-0d3dbac803fff8c33 completed after 10710.93171229s"
+time="2026-04-23T09:00:37Z" level=error msg="i-0d3dbac803fff8c33> failed to send heartbeat during termination grace period: ValidationError: No active Lifecycle Action found with token\n\tstatus code: 400"
+time="2026-04-23T09:00:37Z" level=info msg="i-0d3dbac803fff8c33> event already completed by main goroutine, skipping ABANDON"
+```
+
+---
+
+## Test 6: Stubborn pod that ignores SIGTERM beyond the cap (April 23, 2026)
+
+Adversarial run where the pod declares `terminationGracePeriodSeconds: 1200` (higher than the LM cap of `900s`) **and** installs a `SIGTERM` trap that sleeps `1500s` — longer than both the pod's declared grace and the LM's global cap. Intent: observe who force-kills first when the pod refuses to exit.
+
+### Setup
+```
+lifecycle manager image used: docker.intuit.com/docker-rmt/keikoproj/lifecycle-manager:v0.6.6
+cluster: ip-fmea1-e2e-usw2-k8s
+namespace: sandbox-sandbox-draychevcustgitprima-usw2-e2e
+pod: drain-blocker-98cc7fbb9-hrpjd
+    running on node: ip-10-235-115-212.us-west-2.compute.internal
+Instance id: i-0d445af41a1a6df3a
+ASG: ip-fmea1-e2e-usw2-k8s-instance-manager-nodes
+Availability Zone: us-west-2b
+Termination initiated: 2026-04-23T23:40:14Z (user-requested scale-in)
+
+pod spec:
+    spec:
+      terminationGracePeriodSeconds: 1200   # 20 min (larger than LM cap of 900s)
+      containers:
+      - name: sleeper
+        command:
+        - sh
+        - -c
+        - |
+          trap 'echo "SIGTERM received at $(date) — INTENTIONALLY sleeping 1500s to exceed 900s cap"; sleep 1500; exit 0' TERM
+          while true; do sleep 1; done
+    # PDB: maxUnavailable: 0, selector matches drain-blocker
+
+container settings (lifecycle-manager — same as Tests 3/5, fully production values):
+     containers:
+     - command:
+       - /bin/lifecycle-manager
+       - serve
+       - --queue-name=ip-fmea1-e2e-usw2-k8s-lifecycle-manager
+       - --region=us-west-2
+       - --polling-interval=10
+       - --drain-timeout=3600                # 1 h per drain attempt
+       - --drain-timeout-unknown=60
+       - --max-time-to-process=10800         # 3 h overall heartbeat window
+       - --max-drain-concurrency=32
+       - --max-termination-grace-period=900  # 15 min cap on per-pod grace
+       - --with-deregister=true
+       - --deregister-target-types=classic-elb,target-group
+       - --log-level=debug
+       image: docker.intuit.com/docker-rmt/keikoproj/lifecycle-manager:v0.6.6
+       name: lifecycle-manager
+```
+
+### Test Result
+
+**Event — ABANDON due to `drain-timeout` preempting the 900s Kubernetes force-kill deadline**
+```
+23:40:14Z  Event received, drain starts (blocked by PDB maxUnavailable: 0)
+           Heartbeats every 2.5 min (1/72 → 71/72)
+           drain-timeout=3600s expires; LM retries drain:
+             00:40:15Z  "global timeout reached: 1h0m0s" → retry #1
+             01:40:20Z  "global timeout reached: 1h0m0s" → retry #2
+
+02:37:53Z  Heartbeat 72/72 → max-time-to-process TIMEOUT after 2h57m39s
+           → deleting pod (grace period: 900s — capped from pod's 1200s)
+           → publishing event: HeartbeatTimeoutGracefulTermination
+           → Kubernetes DELETE issued; K8s force-kill deadline = 02:52:53Z
+
+02:40:20Z  (2m 27s after deletePod) current drain attempt hits
+           "global timeout reached: 1h0m0s" again
+           → "error when waiting for pod ... to terminate: context deadline exceeded"
+           → LM has exhausted its drain retries within the 3h window
+
+02:40:38Z  LM sets lifecycle event as ABANDON after 10823.99s (~3h0m24s)
+           → ASG now owns the termination; instance goes to Terminating
+
+02:40:42Z+ Background goroutine keeps trying to heartbeat; API rejects:
+           "No active Lifecycle Action found with token ..." (hook already abandoned)
+
+02:45:06Z  Pod finally gone (~7m13s after deletePod, well inside the 900s cap)
+           → "all non-daemonset pods terminated on node"
+           → "event already completed by main goroutine, skipping ABANDON"
+```
+
+### What actually force-killed the stubborn pod?
+
+Not Kubernetes — **the ASG did**. Because LM returned `ABANDON`, the ASG proceeded to terminate `i-0d445af41a1a6df3a` immediately. The node (kubelet) stopped running before Kubernetes' 900s force-kill deadline at 02:52:53Z, so the pod object disappeared as a side effect of the node going away at ~02:45:06Z — not from K8s SIGKILL at the capped deadline.
+
+### Key finding: `drain-timeout` can preempt `max-termination-grace-period`
+
+There is a timing interaction between two independent timers once heartbeat timeout triggers graceful deletion:
+
+| Timer | Value | Scope |
+|---|---|---|
+| `max-time-to-process` | 10800s (3h) | Whole lifecycle event; triggers heartbeat-timeout graceful deletion |
+| `max-termination-grace-period` | 900s (15m) | Cap applied to pod's `terminationGracePeriodSeconds` on DELETE |
+| `drain-timeout` | 3600s (1h) | Each `kubectl drain` attempt; retried on failure |
+
+When the heartbeat timeout fires late in the 3h window (here at 2h57m39s), the LM issues `DELETE pod --grace-period=900`, then re-enters `waitForPodsWithHeartbeat` — but that wait is bounded by the **current drain attempt's** 1h `drain-timeout`, which in this run had only 2m 27s remaining. The wait ctx expires at 02:40:20Z, long before the 900s K8s deadline at 02:52:53Z, and LM marks the event `ABANDON`.
+
+### Validation matrix
+| Check | Evidence | Result |
+|---|---|---|
+| Event received | `i-0d445af41a1a6df3a> received termination event` at 23:40:14Z | Pass |
+| 71 heartbeats over ~3 h | `sending heartbeat (1/72)` → `(71/72)` at 2.5 min intervals | Pass |
+| PDB blocked drain | `Cannot evict pod ... disruption budget` retries continuously | Pass |
+| drain-timeout retries fire at 1 h cadence | `global timeout reached: 1h0m0s` at 00:40:15Z and 01:40:20Z | Pass |
+| Heartbeat-timeout graceful delete fired at correct time | `heartbeat extended over threshold after 2h57m39s` at 02:37:53Z | Pass |
+| Grace period cap enforced on DELETE | `(grace period: 900s)` — pod's 1200s capped to 900s | Pass |
+| K8s event published | `publishing event: HeartbeatTimeoutGracefulTermination` | Pass |
+| Final drain attempt preempted graceful wait | `global timeout reached: 1h0m0s` at 02:40:20Z (2m 27s after delete) | Observed |
+| LM outcome | `setting lifecycle event as completed with result: ABANDON` after 10823.99s | ABANDON |
+| Stubborn pod terminated (by ASG, not K8s SIGKILL) | `all non-daemonset pods terminated on node` at 02:45:06Z (before 02:52:53Z cap) | Pass |
+| ABANDON race guarded | `event already completed by main goroutine, skipping ABANDON` | Pass |
+| Post-abandon heartbeats rejected | `No active Lifecycle Action found with token ...` 02:40:42Z onward | Pass |
+
+### Conclusion / recommendation
+
+- The `max-termination-grace-period` cap **is** applied correctly on the DELETE call (pod's 1200s → 900s). That behavior matches the design.
+- However, when `max-time-to-process` fires late in the window, the per-attempt `drain-timeout` can win the race and cause `ABANDON` before K8s gets a chance to enforce the 900s SIGKILL.
+- In production with well-behaved pods (Test 5) this is a non-issue — pods exit inside their grace period and the run ends in `CONTINUE`. This failure mode is limited to **truly stubborn workloads that refuse to exit on SIGTERM**, and even then the instance still terminates (the ASG handles it after `ABANDON`), just via a different code path than the intended "graceful deletion → K8s SIGKILL → `CONTINUE`".
+- Operators should be aware that for the `CONTINUE`-via-heartbeat-timeout path to succeed with a stubborn pod, the relationship should be `drain-timeout` remaining at graceful-delete time ≥ `max-termination-grace-period`. Practically, setting `max-time-to-process` such that the heartbeat-timeout fires with at least one full `drain-timeout` window left (i.e., `max-time-to-process ≤ N × drain-timeout − max-termination-grace-period`) avoids this race. With the current values (3h, 1h, 15m), the safe ceiling would be `max-time-to-process ≤ 2h45m` if we want the 900s cap to be respected by K8s rather than short-circuited by ASG `ABANDON`.
+
+---
+
+## Test 7: Stubborn pod under redesigned escalation flow (EXECUTED — 2026-04-28)
+
+Re-run of the Test 6 adversarial scenario after the redesign that:
+
+1. Moves the graceful force-delete escalation out of the heartbeat goroutine and into `drainNodeTarget` (so a single goroutine owns the termination decision and the A-vs-B race is gone).
+2. Reduces `sendHeartbeat` to a pure heartbeat with a `max-time-to-process` safety cap.
+3. Adds `validateServe()` enforcement that `max-time-to-process ≥ (drain-retries × drain-timeout) + max-termination-grace-period + 30s`.
+
+### Setup (as run)
+```
+lifecycle manager image: custom build with redesign (cluster deployment)
+cluster: ip-fmea1-e2e-usw2-k8s (per Test 6 lineage)
+namespace: sandbox-sandbox-draychevcustgitprima-usw2-e2e
+
+pod spec (identical to Test 6):
+    spec:
+      terminationGracePeriodSeconds: 1200
+      containers:
+      - name: sleeper
+        command:
+        - sh
+        - -c
+        - |
+          trap 'echo "SIGTERM received at $(date) — INTENTIONALLY sleeping 1500s to exceed 900s cap"; sleep 1500; exit 0' TERM
+          while true; do sleep 1; done
+    # PDB: maxUnavailable: 0
+
+container settings (lifecycle-manager):
+     - --queue-name=ip-fmea1-e2e-usw2-k8s-lifecycle-manager
+     - --region=us-west-2
+     - --polling-interval=10
+     - --drain-timeout=3600
+     - --drain-timeout-unknown=60
+     - --max-time-to-process=11750         # satisfies validateServe: ceiling = 3×3600+900+30 = 11730
+     - --max-drain-concurrency=32
+     - --max-termination-grace-period=900
+     - --with-deregister=true
+     - --deregister-target-types=classic-elb,target-group
+     - --log-level=debug
+```
+
+### Actual outcome
+| Field | Value |
+|---|---|
+| Instance | `i-09a78acac8bee407f` |
+| Event ID | `35c6774b-fe4c-bf3f-0f84-2ef8956d6c07` |
+| Wall-clock processing | **11727.1 s** (~**3 h 15 m 27 s**) from event start to completion log |
+| LM result | **`CONTINUE`** (lifecycle completed successfully) |
+| Representative log | `time="2026-04-28T10:46:25Z" level=info msg="event 35c6774b-fe4c-bf3f-0f84-2ef8956d6c07 for instance i-09a78acac8bee407f completed after 11727.105154335s"` |
+
+### Actual timeline (high level)
+```
+T=0              Event received; PDB-blocked drain; heartbeats continue on cadence
+T≈1h / 2h / 3h   Three full drain-timeout cycles (3600s each) exhaust retries
+T≈3h             drainNode fails → escalateDrainFailure: force-delete with grace=900s, wait up to 930s
+T≈3h15m27s       Pods gone; deregister / delete node; CompleteEvent → CONTINUE
+```
+
+### Validation matrix (actual)
+| Check | Evidence | Result |
+|---|---|---|
+| Long run completes | completion log at ~11727 s | Pass |
+| LM outcome | `CONTINUE` (not `ABANDON`) | Pass |
+| Race vs Test 6 | Main path owned escalation; heartbeat did not decide termination | Pass |
+| validateServe | `--max-time-to-process=11750` ≥ required ceiling 11730 | Pass |
+
+### Conclusion
+
+The overnight run matched the redesigned model: enough wall time for three drain attempts, then in-process graceful force-delete and wait for the capped grace window, then successful lifecycle completion. The Test 6 failure mode (drain timeout winning over the 900s K8s kill window) did not recur.

--- a/pkg/service/events.go
+++ b/pkg/service/events.go
@@ -69,10 +69,10 @@ const (
 	EventReasonInstanceDeregisterFailed EventReason = "InstanceDeregisterFailed"
 	// EventMessageInstanceDeregisterFailed is the message for a successful classic elb deregister event
 	EventMessageInstanceDeregisterFailed = "instance %v has failed to deregister from classic-elb %v: %v"
-	// EventReasonHeartbeatTimeoutGracefulTermination is the reason for a heartbeat-timeout triggered pod cleanup
-	EventReasonHeartbeatTimeoutGracefulTermination EventReason = "HeartbeatTimeoutGracefulTermination"
-	// EventMessageHeartbeatTimeoutGracefulTermination is the message for a heartbeat-timeout triggered pod cleanup
-	EventMessageHeartbeatTimeoutGracefulTermination = "instance %v exceeded max-time-to-process, deleted %v pods for graceful termination on node %v"
+	// EventReasonGracefulPodDeletionAfterDrainFailed is the reason for a drain-failure escalation that force-deletes pods with the capped grace period
+	EventReasonGracefulPodDeletionAfterDrainFailed EventReason = "GracefulPodDeletionAfterDrainFailed"
+	// EventMessageGracefulPodDeletionAfterDrainFailed is the message for a drain-failure escalation that force-deletes pods with the capped grace period
+	EventMessageGracefulPodDeletionAfterDrainFailed = "instance %v drain failed, deleted %v pods for graceful termination on node %v"
 )
 
 var (
@@ -83,16 +83,16 @@ var (
 
 	// EventLevels is a map of event reasons and their event level
 	EventLevels = map[EventReason]string{
-		EventReasonLifecycleHookReceived:       EventLevelNormal,
-		EventReasonLifecycleHookProcessed:      EventLevelNormal,
-		EventReasonLifecycleHookFailed:         EventLevelWarning,
-		EventReasonNodeDrainSucceeded:          EventLevelNormal,
-		EventReasonNodeDrainFailed:             EventLevelWarning,
-		EventReasonTargetDeregisterSucceeded:   EventLevelNormal,
-		EventReasonTargetDeregisterFailed:      EventLevelWarning,
+		EventReasonLifecycleHookReceived:               EventLevelNormal,
+		EventReasonLifecycleHookProcessed:              EventLevelNormal,
+		EventReasonLifecycleHookFailed:                 EventLevelWarning,
+		EventReasonNodeDrainSucceeded:                  EventLevelNormal,
+		EventReasonNodeDrainFailed:                     EventLevelWarning,
+		EventReasonTargetDeregisterSucceeded:           EventLevelNormal,
+		EventReasonTargetDeregisterFailed:              EventLevelWarning,
 		EventReasonInstanceDeregisterSucceeded:         EventLevelNormal,
 		EventReasonInstanceDeregisterFailed:            EventLevelWarning,
-		EventReasonHeartbeatTimeoutGracefulTermination: EventLevelWarning,
+		EventReasonGracefulPodDeletionAfterDrainFailed: EventLevelWarning,
 	}
 )
 

--- a/pkg/service/nodes.go
+++ b/pkg/service/nodes.go
@@ -310,6 +310,27 @@ func countActivePods(kubeClient kubernetes.Interface, nodeName string) int {
 	return len(pods)
 }
 
+// waitForPodsToBeDeletedPollInterval is the polling cadence used by waitForPodsToBeDeleted.
+var waitForPodsToBeDeletedPollInterval = 5 * time.Second
+
+// waitForPodsToBeDeleted polls every waitForPodsToBeDeletedPollInterval until all
+// non-daemonset pods on the node are deleted, or
+// until the timeout expires. Returns true if all such pods are gone within the
+// timeout, false otherwise.
+func waitForPodsToBeDeleted(kubeClient kubernetes.Interface, nodeName string, timeout time.Duration) bool {
+	if timeout <= 0 {
+		return countActivePods(kubeClient, nodeName) == 0
+	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if countActivePods(kubeClient, nodeName) == 0 {
+			return true
+		}
+		time.Sleep(waitForPodsToBeDeletedPollInterval)
+	}
+	return countActivePods(kubeClient, nodeName) == 0
+}
+
 func deleteNodeUtil(node *v1.Node, client kubernetes.Interface) error {
 
 	var err error = nil

--- a/pkg/service/nodes_test.go
+++ b/pkg/service/nodes_test.go
@@ -7,7 +7,9 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 var (
@@ -336,6 +338,66 @@ func Test_DeletePodsOnNodeCapsGracePeriod(t *testing.T) {
 	remaining, _ := kubeClient.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
 	if len(remaining.Items) != 0 {
 		t.Fatalf("expected all pods deleted, but %d remain", len(remaining.Items))
+	}
+}
+
+func Test_DeletePodsOnNodeDeleteUsesEffectiveGracePeriod(t *testing.T) {
+	t.Log("Test_DeletePodsOnNodeDeleteUsesEffectiveGracePeriod: DELETE uses min(pod.Spec.TerminationGracePeriodSeconds, max) — short pod grace below 900s cap, long pod grace capped to max")
+	var graceSeen []int64
+	kubeClient := fake.NewSimpleClientset()
+	kubeClient.PrependReactor("delete", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		if da, ok := action.(k8stesting.DeleteAction); ok {
+			if g := da.GetDeleteOptions().GracePeriodSeconds; g != nil {
+				graceSeen = append(graceSeen, *g)
+			}
+		}
+		return false, nil, nil
+	})
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+	}
+	kubeClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+
+	shortGrace := int64(45)
+	longGrace := int64(1200)
+	p1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "short-grace", Namespace: "default"},
+		Spec:       v1.PodSpec{NodeName: "test-node", TerminationGracePeriodSeconds: &shortGrace},
+		Status:     v1.PodStatus{Phase: v1.PodRunning},
+	}
+	p2 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "long-grace", Namespace: "ns2"},
+		Spec:       v1.PodSpec{NodeName: "test-node", TerminationGracePeriodSeconds: &longGrace},
+		Status:     v1.PodStatus{Phase: v1.PodRunning},
+	}
+	kubeClient.CoreV1().Pods("default").Create(context.Background(), p1, metav1.CreateOptions{})
+	kubeClient.CoreV1().Pods("ns2").Create(context.Background(), p2, metav1.CreateOptions{})
+
+	deleted, err := deletePodsOnNode(kubeClient, "test-node", 900)
+	if err != nil {
+		t.Fatalf("deletePodsOnNode: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("expected 2 pods deleted, got %d", deleted)
+	}
+	if len(graceSeen) != 2 {
+		t.Fatalf("expected 2 delete calls observed, got %d graces: %v", len(graceSeen), graceSeen)
+	}
+	// Order follows list iteration; both values must appear exactly once.
+	var has45, has900 bool
+	for _, g := range graceSeen {
+		switch g {
+		case 45:
+			has45 = true
+		case 900:
+			has900 = true
+		default:
+			t.Errorf("unexpected grace period passed to Delete: %d", g)
+		}
+	}
+	if !has45 || !has900 {
+		t.Fatalf("expected graces 45 and 900, got %v", graceSeen)
 	}
 }
 

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -290,15 +290,14 @@ func (mgr *Manager) drainNodeTarget(event *LifecycleEvent) error {
 	return nil
 }
 
-// escalateDrainFailureWaitSlackSeconds is added to gracePeriod when waiting for pod
-// objects to disappear after force-delete (API delay after kubelet SIGKILL).
-// Unit tests may set this to 0 to keep escalation timeout tests fast.
-var escalateDrainFailureWaitSlackSeconds int64 = 30
+// EscalateDrainFailureWaitSlackSeconds is added to gracePeriod when waiting for
+// pod objects to disappear after force-delete (API delay after kubelet SIGKILL).
+var EscalateDrainFailureWaitSlackSeconds int64 = 30
 
 // escalateDrainFailure attempts to recover from a drain failure by force-deleting
 // non-daemonset pods on the node with the capped grace period, then waiting for
 // Kubernetes to fully terminate them (SIGTERM -> SIGKILL at grace boundary).
-// Returns nil if pods are gone within (grace + escalateDrainFailureWaitSlackSeconds);
+// Returns nil if pods are gone within (grace + EscalateDrainFailureWaitSlackSeconds);
 // returns an error otherwise, in which case the caller should propagate it so
 // handleEvent fails the lifecycle hook with ABANDON.
 func escalateDrainFailure(event *LifecycleEvent, kubeClient kubernetes.Interface, gracePeriod int64) error {
@@ -321,7 +320,7 @@ func escalateDrainFailure(event *LifecycleEvent, kubeClient kubernetes.Interface
 	publishKubernetesEvent(kubeClient,
 		newKubernetesEvent(EventReasonGracefulPodDeletionAfterDrainFailed, getMessageFields(event, msg)))
 
-	waitSeconds := gracePeriod + escalateDrainFailureWaitSlackSeconds
+	waitSeconds := gracePeriod + EscalateDrainFailureWaitSlackSeconds
 	waitTimeout := time.Duration(waitSeconds) * time.Second
 	if !waitForPodsToBeDeleted(kubeClient, nodeName, waitTimeout) {
 		log.Errorf("%v> pods still present after %ds graceful force-delete window on node %v",

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -267,14 +268,68 @@ func (mgr *Manager) drainNodeTarget(event *LifecycleEvent) error {
 		failMsg := fmt.Sprintf(EventMessageNodeDrainFailed, event.referencedNode.Name, err)
 		kEvent := newKubernetesEvent(EventMessageNodeDrainFailed, getMessageFields(event, failMsg))
 		publishKubernetesEvent(kubeClient, kEvent)
-		return err
+
+		// Escalate: drain exhausted its retries (typically PDB-blocked or pod
+		// ignoring SIGTERM). Force-delete remaining non-daemonset pods using
+		// the capped MaxTerminationGracePeriod and wait for Kubernetes to
+		// enforce the grace deadline (SIGTERM -> SIGKILL). Returning nil here
+		// means handleEvent will proceed to LB deregister and node delete,
+		// resulting in CompleteEvent -> CONTINUE rather than FailEvent -> ABANDON.
+		if escalateErr := escalateDrainFailure(event, kubeClient, ctx.MaxTerminationGracePeriod); escalateErr != nil {
+			return escalateErr
+		}
+	} else {
+		log.Infof("%v> completed drain for node/%v", event.EC2InstanceID, event.referencedNode.Name)
 	}
-	log.Infof("%v> completed drain for node/%v", event.EC2InstanceID, event.referencedNode.Name)
+
 	event.SetDrainCompleted(true)
 	metrics.AddCounter(SuccessfulNodeDrainTotalMetric, 1)
 
 	kEvent := newKubernetesEvent(EventReasonNodeDrainSucceeded, getMessageFields(event, successMsg))
 	publishKubernetesEvent(kubeClient, kEvent)
+	return nil
+}
+
+// escalateDrainFailureWaitSlackSeconds is added to gracePeriod when waiting for pod
+// objects to disappear after force-delete (API delay after kubelet SIGKILL).
+// Unit tests may set this to 0 to keep escalation timeout tests fast.
+var escalateDrainFailureWaitSlackSeconds int64 = 30
+
+// escalateDrainFailure attempts to recover from a drain failure by force-deleting
+// non-daemonset pods on the node with the capped grace period, then waiting for
+// Kubernetes to fully terminate them (SIGTERM -> SIGKILL at grace boundary).
+// Returns nil if pods are gone within (grace + escalateDrainFailureWaitSlackSeconds);
+// returns an error otherwise, in which case the caller should propagate it so
+// handleEvent fails the lifecycle hook with ABANDON.
+func escalateDrainFailure(event *LifecycleEvent, kubeClient kubernetes.Interface, gracePeriod int64) error {
+	instanceID := event.EC2InstanceID
+	nodeName := event.referencedNode.Name
+
+	if gracePeriod <= 0 {
+		log.Warnf("%v> drain failed and max-termination-grace-period is %ds; not escalating", instanceID, gracePeriod)
+		return fmt.Errorf("drain failed and graceful escalation is disabled (max-termination-grace-period <= 0)")
+	}
+
+	log.Warnf("%v> drain failed; escalating to graceful force-delete (grace=%ds) on node %v", instanceID, gracePeriod, nodeName)
+	deleted, derr := deletePodsOnNode(kubeClient, nodeName, gracePeriod)
+	if derr != nil {
+		log.Errorf("%v> graceful force-delete failed: %v", instanceID, derr)
+		return fmt.Errorf("graceful force-delete failed after drain failure: %v", derr)
+	}
+
+	msg := fmt.Sprintf(EventMessageGracefulPodDeletionAfterDrainFailed, instanceID, deleted, nodeName)
+	publishKubernetesEvent(kubeClient,
+		newKubernetesEvent(EventReasonGracefulPodDeletionAfterDrainFailed, getMessageFields(event, msg)))
+
+	waitSeconds := gracePeriod + escalateDrainFailureWaitSlackSeconds
+	waitTimeout := time.Duration(waitSeconds) * time.Second
+	if !waitForPodsToBeDeleted(kubeClient, nodeName, waitTimeout) {
+		log.Errorf("%v> pods still present after %ds graceful force-delete window on node %v",
+			instanceID, waitSeconds, nodeName)
+		return fmt.Errorf("pods still present after %ds graceful force-delete window", waitSeconds)
+	}
+
+	log.Infof("%v> graceful force-delete succeeded after drain failure on node %v", instanceID, nodeName)
 	return nil
 }
 
@@ -617,11 +672,9 @@ func (mgr *Manager) handleEvent(event *LifecycleEvent) error {
 	)
 
 	go sendHeartbeat(heartbeatConfig{
-		asgClient:                 mgr.authenticator.ScalingGroupClient,
-		kubeClient:                mgr.authenticator.KubernetesClient,
-		event:                     event,
-		maxTimeToProcessSeconds:   mgr.context.MaxTimeToProcessSeconds,
-		maxTerminationGracePeriod: mgr.context.MaxTerminationGracePeriod,
+		asgClient:               mgr.authenticator.ScalingGroupClient,
+		event:                   event,
+		maxTimeToProcessSeconds: mgr.context.MaxTimeToProcessSeconds,
 	})
 
 	// Annotate node with InProgressAnnotationKey = EventBody for resuming in case of crash

--- a/pkg/service/server_test.go
+++ b/pkg/service/server_test.go
@@ -29,7 +29,7 @@ func init() {
 	WaiterMaxAttempts = 3
 	NodeAgeCacheTTL = 100
 	waitForPodsToBeDeletedPollInterval = 10 * time.Millisecond
-	escalateDrainFailureWaitSlackSeconds = 30
+	EscalateDrainFailureWaitSlackSeconds = 30
 }
 
 func _completeEventAfter(event *LifecycleEvent, t time.Duration) {
@@ -666,8 +666,8 @@ func Test_EscalateDrainFailureNegativeGrace(t *testing.T) {
 
 func Test_EscalateDrainFailurePodsRemainAfterDelete(t *testing.T) {
 	t.Log("Test_EscalateDrainFailurePodsRemainAfterDelete: simulates stubborn pod — DELETE succeeds but pod never leaves the API (wait times out)")
-	defer func() { escalateDrainFailureWaitSlackSeconds = 30 }()
-	escalateDrainFailureWaitSlackSeconds = 0
+	defer func() { EscalateDrainFailureWaitSlackSeconds = 30 }()
+	EscalateDrainFailureWaitSlackSeconds = 0
 
 	kubeClient := fake.NewSimpleClientset()
 	kubeClient.PrependReactor("delete", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {

--- a/pkg/service/server_test.go
+++ b/pkg/service/server_test.go
@@ -8,6 +8,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	apimachinery_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -26,6 +28,8 @@ func init() {
 	WaiterMaxDelay = 2 * time.Second
 	WaiterMaxAttempts = 3
 	NodeAgeCacheTTL = 100
+	waitForPodsToBeDeletedPollInterval = 10 * time.Millisecond
+	escalateDrainFailureWaitSlackSeconds = 30
 }
 
 func _completeEventAfter(event *LifecycleEvent, t time.Duration) {
@@ -534,4 +538,268 @@ func Test_Worker(t *testing.T) {
 		t.Fatalf("expected completed events: %v, got: %v", expectedCompletedEvents, mgr.completedEvents)
 	}
 
+}
+
+func Test_EscalateDrainFailureSuccess(t *testing.T) {
+	t.Log("Test_EscalateDrainFailureSuccess: drain failed -> escalation force-deletes pods, returns nil")
+	kubeClient := fake.NewSimpleClientset()
+
+	node := &v1.Node{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "test-node"},
+		Spec:       v1.NodeSpec{ProviderID: "aws:///us-west-2a/i-1234567890"},
+	}
+	kubeClient.CoreV1().Nodes().Create(context.Background(), node, apimachinery_v1.CreateOptions{})
+
+	pod := &v1.Pod{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec:       v1.PodSpec{NodeName: "test-node"},
+	}
+	kubeClient.CoreV1().Pods("default").Create(context.Background(), pod, apimachinery_v1.CreateOptions{})
+
+	event := &LifecycleEvent{
+		AutoScalingGroupName: "my-asg",
+		EC2InstanceID:        "i-1234567890",
+		LifecycleHookName:    "my-hook",
+		referencedNode:       *node,
+	}
+
+	if err := escalateDrainFailure(event, kubeClient, 1); err != nil {
+		t.Fatalf("expected escalateDrainFailure to succeed, got: %v", err)
+	}
+
+	pods, _ := kubeClient.CoreV1().Pods("default").List(context.Background(), apimachinery_v1.ListOptions{})
+	if len(pods.Items) != 0 {
+		t.Fatalf("expected pod to be deleted by escalation, but %d pods remain", len(pods.Items))
+	}
+}
+
+func Test_EscalateDrainFailureDaemonSetSurvives(t *testing.T) {
+	t.Log("Test_EscalateDrainFailureDaemonSetSurvives: DaemonSet pods are not deleted during escalation")
+	kubeClient := fake.NewSimpleClientset()
+
+	node := &v1.Node{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "test-node"},
+		Spec:       v1.NodeSpec{ProviderID: "aws:///us-west-2a/i-1234567890"},
+	}
+	kubeClient.CoreV1().Nodes().Create(context.Background(), node, apimachinery_v1.CreateOptions{})
+
+	dsPod := &v1.Pod{
+		ObjectMeta: apimachinery_v1.ObjectMeta{
+			Name:      "ds-pod",
+			Namespace: "kube-system",
+			OwnerReferences: []apimachinery_v1.OwnerReference{
+				{Kind: "DaemonSet", Name: "my-ds", APIVersion: "apps/v1"},
+			},
+		},
+		Spec: v1.PodSpec{NodeName: "test-node"},
+	}
+	kubeClient.CoreV1().Pods("kube-system").Create(context.Background(), dsPod, apimachinery_v1.CreateOptions{})
+
+	regularPod := &v1.Pod{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "regular-pod", Namespace: "default"},
+		Spec:       v1.PodSpec{NodeName: "test-node"},
+	}
+	kubeClient.CoreV1().Pods("default").Create(context.Background(), regularPod, apimachinery_v1.CreateOptions{})
+
+	event := &LifecycleEvent{
+		AutoScalingGroupName: "my-asg",
+		EC2InstanceID:        "i-1234567890",
+		LifecycleHookName:    "my-hook",
+		referencedNode:       *node,
+	}
+
+	if err := escalateDrainFailure(event, kubeClient, 1); err != nil {
+		t.Fatalf("expected escalateDrainFailure to succeed, got: %v", err)
+	}
+
+	dsPods, _ := kubeClient.CoreV1().Pods("kube-system").List(context.Background(), apimachinery_v1.ListOptions{})
+	if len(dsPods.Items) != 1 {
+		t.Fatalf("expected daemonset pod to survive escalation, got %d pods", len(dsPods.Items))
+	}
+	regularPods, _ := kubeClient.CoreV1().Pods("default").List(context.Background(), apimachinery_v1.ListOptions{})
+	if len(regularPods.Items) != 0 {
+		t.Fatalf("expected regular pod to be deleted by escalation, got %d pods", len(regularPods.Items))
+	}
+}
+
+func Test_EscalateDrainFailureGracePeriodZero(t *testing.T) {
+	t.Log("Test_EscalateDrainFailureGracePeriodZero: when grace period <= 0, escalation refuses to run and returns an error")
+	kubeClient := fake.NewSimpleClientset()
+	node := &v1.Node{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "test-node"},
+		Spec:       v1.NodeSpec{ProviderID: "aws:///us-west-2a/i-1234567890"},
+	}
+	kubeClient.CoreV1().Nodes().Create(context.Background(), node, apimachinery_v1.CreateOptions{})
+
+	event := &LifecycleEvent{
+		AutoScalingGroupName: "my-asg",
+		EC2InstanceID:        "i-1234567890",
+		LifecycleHookName:    "my-hook",
+		referencedNode:       *node,
+	}
+
+	if err := escalateDrainFailure(event, kubeClient, 0); err == nil {
+		t.Fatal("expected escalateDrainFailure to return an error when grace period is 0, got nil")
+	}
+}
+
+func Test_EscalateDrainFailureNegativeGrace(t *testing.T) {
+	t.Log("Test_EscalateDrainFailureNegativeGrace: negative max-termination-grace-period is treated as disabled")
+	kubeClient := fake.NewSimpleClientset()
+	node := &v1.Node{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "test-node"},
+		Spec:       v1.NodeSpec{ProviderID: "aws:///us-west-2a/i-1234567890"},
+	}
+	kubeClient.CoreV1().Nodes().Create(context.Background(), node, apimachinery_v1.CreateOptions{})
+
+	event := &LifecycleEvent{
+		AutoScalingGroupName: "my-asg",
+		EC2InstanceID:        "i-1234567890",
+		LifecycleHookName:    "my-hook",
+		referencedNode:       *node,
+	}
+
+	if err := escalateDrainFailure(event, kubeClient, -1); err == nil {
+		t.Fatal("expected escalateDrainFailure to return an error when grace period is negative, got nil")
+	}
+}
+
+func Test_EscalateDrainFailurePodsRemainAfterDelete(t *testing.T) {
+	t.Log("Test_EscalateDrainFailurePodsRemainAfterDelete: simulates stubborn pod — DELETE succeeds but pod never leaves the API (wait times out)")
+	defer func() { escalateDrainFailureWaitSlackSeconds = 30 }()
+	escalateDrainFailureWaitSlackSeconds = 0
+
+	kubeClient := fake.NewSimpleClientset()
+	kubeClient.PrependReactor("delete", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		// Succeed without removing the pod from the fake store (stubborn pod / broken API semantics).
+		return true, nil, nil
+	})
+
+	node := &v1.Node{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "test-node"},
+		Spec:       v1.NodeSpec{ProviderID: "aws:///us-west-2a/i-1234567890"},
+	}
+	kubeClient.CoreV1().Nodes().Create(context.Background(), node, apimachinery_v1.CreateOptions{})
+
+	pod := &v1.Pod{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "stuck-pod", Namespace: "default"},
+		Spec:       v1.PodSpec{NodeName: "test-node"},
+		Status:     v1.PodStatus{Phase: v1.PodRunning},
+	}
+	kubeClient.CoreV1().Pods("default").Create(context.Background(), pod, apimachinery_v1.CreateOptions{})
+
+	event := &LifecycleEvent{
+		AutoScalingGroupName: "my-asg",
+		EC2InstanceID:        "i-1234567890",
+		LifecycleHookName:    "my-hook",
+		referencedNode:       *node,
+	}
+
+	err := escalateDrainFailure(event, kubeClient, 2)
+	if err == nil {
+		t.Fatal("expected escalateDrainFailure to fail when pods never disappear, got nil")
+	}
+}
+
+func Test_EscalateDrainFailureProductionLikeGraceHappyPath(t *testing.T) {
+	t.Log("Test_EscalateDrainFailureProductionLikeGraceHappyPath: max grace 900 with pod TGP 1200 — DELETE caps at 900, fake removes pod immediately so wait succeeds (e2e stubborn-wait is integration-only)")
+	kubeClient := fake.NewSimpleClientset()
+
+	node := &v1.Node{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "test-node"},
+		Spec:       v1.NodeSpec{ProviderID: "aws:///us-west-2a/i-1234567890"},
+	}
+	kubeClient.CoreV1().Nodes().Create(context.Background(), node, apimachinery_v1.CreateOptions{})
+
+	longGrace := int64(1200)
+	pod := &v1.Pod{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "long-tgp-pod", Namespace: "default"},
+		Spec:       v1.PodSpec{NodeName: "test-node", TerminationGracePeriodSeconds: &longGrace},
+		Status:     v1.PodStatus{Phase: v1.PodRunning},
+	}
+	kubeClient.CoreV1().Pods("default").Create(context.Background(), pod, apimachinery_v1.CreateOptions{})
+
+	event := &LifecycleEvent{
+		AutoScalingGroupName: "my-asg",
+		EC2InstanceID:        "i-1234567890",
+		LifecycleHookName:    "my-hook",
+		referencedNode:       *node,
+	}
+
+	if err := escalateDrainFailure(event, kubeClient, 900); err != nil {
+		t.Fatalf("expected escalation to succeed when API removes pod after delete: %v", err)
+	}
+}
+
+func Test_WaitForPodsToBeDeletedAlreadyGone(t *testing.T) {
+	t.Log("Test_WaitForPodsToBeDeletedAlreadyGone: returns true immediately when no pods exist")
+	kubeClient := fake.NewSimpleClientset()
+	node := &v1.Node{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "test-node"},
+		Spec:       v1.NodeSpec{ProviderID: "aws:///us-west-2a/i-1234567890"},
+	}
+	kubeClient.CoreV1().Nodes().Create(context.Background(), node, apimachinery_v1.CreateOptions{})
+
+	if !waitForPodsToBeDeleted(kubeClient, "test-node", 1*time.Second) {
+		t.Fatal("expected waitForPodsToBeDeleted to return true when there are no active pods")
+	}
+}
+
+func Test_WaitForPodsToBeDeletedTimeout(t *testing.T) {
+	t.Log("Test_WaitForPodsToBeDeletedTimeout: returns false when a pod is still present after the timeout")
+	kubeClient := fake.NewSimpleClientset()
+	node := &v1.Node{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "test-node"},
+		Spec:       v1.NodeSpec{ProviderID: "aws:///us-west-2a/i-1234567890"},
+	}
+	kubeClient.CoreV1().Nodes().Create(context.Background(), node, apimachinery_v1.CreateOptions{})
+	pod := &v1.Pod{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "stuck-pod", Namespace: "default"},
+		Spec:       v1.PodSpec{NodeName: "test-node"},
+	}
+	kubeClient.CoreV1().Pods("default").Create(context.Background(), pod, apimachinery_v1.CreateOptions{})
+
+	if waitForPodsToBeDeleted(kubeClient, "test-node", 50*time.Millisecond) {
+		t.Fatal("expected waitForPodsToBeDeleted to return false while the pod is still present")
+	}
+}
+
+func Test_WaitForPodsToBeDeletedIgnoresSucceededPods(t *testing.T) {
+	t.Log("Test_WaitForPodsToBeDeletedIgnoresSucceededPods: terminal pods are not counted as active")
+	kubeClient := fake.NewSimpleClientset()
+	node := &v1.Node{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "test-node"},
+		Spec:       v1.NodeSpec{ProviderID: "aws:///us-west-2a/i-1234567890"},
+	}
+	kubeClient.CoreV1().Nodes().Create(context.Background(), node, apimachinery_v1.CreateOptions{})
+	pod := &v1.Pod{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "done-pod", Namespace: "default"},
+		Spec:       v1.PodSpec{NodeName: "test-node"},
+		Status:     v1.PodStatus{Phase: v1.PodSucceeded},
+	}
+	kubeClient.CoreV1().Pods("default").Create(context.Background(), pod, apimachinery_v1.CreateOptions{})
+
+	if !waitForPodsToBeDeleted(kubeClient, "test-node", 500*time.Millisecond) {
+		t.Fatal("expected waitForPodsToBeDeleted true when only succeeded pods exist on node")
+	}
+}
+
+func Test_WaitForPodsToBeDeletedZeroTimeoutWithRunningPod(t *testing.T) {
+	t.Log("Test_WaitForPodsToBeDeletedZeroTimeoutWithRunningPod: timeout<=0 performs a single check")
+	kubeClient := fake.NewSimpleClientset()
+	node := &v1.Node{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "test-node"},
+		Spec:       v1.NodeSpec{ProviderID: "aws:///us-west-2a/i-1234567890"},
+	}
+	kubeClient.CoreV1().Nodes().Create(context.Background(), node, apimachinery_v1.CreateOptions{})
+	pod := &v1.Pod{
+		ObjectMeta: apimachinery_v1.ObjectMeta{Name: "running-pod", Namespace: "default"},
+		Spec:       v1.PodSpec{NodeName: "test-node"},
+		Status:     v1.PodStatus{Phase: v1.PodRunning},
+	}
+	kubeClient.CoreV1().Pods("default").Create(context.Background(), pod, apimachinery_v1.CreateOptions{})
+
+	if waitForPodsToBeDeleted(kubeClient, "test-node", 0) {
+		t.Fatal("expected false for zero timeout while a running pod exists")
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/keikoproj/lifecycle-manager/issues/283

## Summary

This change fixes a **race between the main drain path and the background heartbeat path** that showed up on FMEA when a workload ignored `SIGTERM` for longer than the capped grace period. In that case, `max-termination-grace-period` was applied correctly on `DELETE`, but the lifecycle could still end in **`ABANDON`** because a **per-attempt `drain-timeout`** expired while the process was still waiting for Kubernetes to enforce the grace window.

The fix **moves graceful force-delete into the same goroutine that owns draining** (`drainNodeTarget`), **narrows the heartbeat goroutine to AWS heartbeats only**, and adds **startup validation** so `max-time-to-process` is always large enough for the worst-case main-path duration.

## What changed

- **Heartbeat (`sendHeartbeat`)**  
  Only extends the ASG lifecycle action (`RecordLifecycleActionHeartbeat`). It no longer performs pod deletion or drain decisions. It stops when the event completes, heartbeat extension fails, or a **`max-time-to-process` safety cap** is hit (backstop for a stuck main goroutine).

- **Drain failure escalation (`escalateDrainFailure` in `drainNodeTarget`)**  
  After `drainNode` exhausts retries, LM **force-deletes** remaining non–DaemonSet pods using **`min(pod terminationGracePeriodSeconds, max-termination-grace-period)`**, publishes a Kubernetes event (`GracefulPodDeletionAfterDrainFailed`), then **`waitForPodsToBeDeleted`** until the API shows no active pods (within grace + configurable slack).

- **CLI validation (`validateServe` / `validateServeConfig`)**  
  Enforces:

  `max-time-to-process >= (drain-retries × drain-timeout) + max-termination-grace-period + 30s`

  so the heartbeat keeper does not exit while escalation is still waiting on the kubelet. **Misconfiguration fails fast at process start** (operators must raise `max-time-to-process` when using long drain timeouts, e.g. production-like `3 × 3600s` drains + `900s` grace).

- **Events**  
  Renamed the escalation reason/message to **`GracefulPodDeletionAfterDrainFailed`** (replaces the old heartbeat-timeout naming for this path).

- **Tests**  
  Unit tests cover escalation happy/sad paths, delete grace behavior, `waitForPodsToBeDeleted`, and `validateServeConfig` (including default ceiling and production-like ceiling). Stubborn-pod **wall-clock** behavior remains **cluster e2e** (fake client cannot simulate kubelet SIGKILL timing).

## Operator / migration notes

- Deployments that use **long `drain-timeout` × `drain-retries`** plus **`max-termination-grace-period`** must set **`--max-time-to-process`** at or above the validated ceiling or the pod will **exit on startup** until flags are fixed (intentional guardrail).
- Example from FMEA: ceiling `= 3 × 3600 + 900 + 30 = 11730` → use **`11750`** (or any value `≥ 11730`).

## References

- E2E write-up and matrices: `pkg/service/e2e-ip-fmea2-results-v2.39.15.md` (Tests 6–7).

---

## E2E testing (cluster `ip-fmea1-e2e-usw2-k8s`)

Exercised on **`ip-fmea1-e2e-usw2-k8s`** with lifecycle-manager queue **`ip-fmea1-e2e-usw2-k8s-lifecycle-manager`**, region **`us-west-2`**, workload namespace **`sandbox-sandbox-draychevcustgitprima-usw2-e2e`**. Full detail: **`pkg/service/e2e-ip-fmea2-results-v2.39.15.md`**.

| Test | Intent | Result (high level) |
|------|--------|---------------------|
| **Earlier FMEA runs** | Repeatable PDB-blocked drain + heartbeat window; pod within grace cap | **`CONTINUE`** after ~3h; pre-refactor heartbeat-driven path behaved as designed. |
| **Test 1** | Adversarial: PDB + pod ignores SIGTERM, `terminationGracePeriodSeconds` 1200, cap 900, `drain-timeout=3600`, `max-time-to-process=10800` | **`ABANDON`**: DELETE used 900s grace correctly, but **`drain-timeout`** on the final drain attempt cut short the wait before K8s hit the 900s kill boundary; instance still terminated via ASG (documented in repo). |
| **Test 2 (post-redesign)** | Same adversarial setup; branch image; `--max-time-to-process=11750` (≥ ceiling **11730**) | **`CONTINUE`** after **~11727 s (~3h 15m)** on instance **`i-09a78acac8bee407f`**; three 1h drain retries, then in-process force-delete + wait, then deregister/delete node. |

**Reviewer takeaway:** FMEA showed the old two-goroutine design could **`ABANDON`** stubborn pods despite a correct grace cap. The redesign plus **`validateServe`** was re-validated overnight with **`CONTINUE`** and timings consistent with **3 × drain-timeout + grace window**.

---

Another Test Run:
<img width="774" height="652" alt="image" src="https://github.com/user-attachments/assets/e712b77b-3147-4222-9a6d-62293bec3f68" />
<img width="733" height="560" alt="image" src="https://github.com/user-attachments/assets/3ac412db-b085-4bf9-86f3-944fe526f23a" />


---

## Unit / CI

- `go test ./...` (includes new tests for escalation, `waitForPodsToBeDeleted`, `deletePodsOnNode` DELETE grace, and `cmd` `validateServeConfig`).
